### PR TITLE
Fix 'implicit declaration of function htonl / htons' compiler warnings

### DIFF
--- a/limelight-common/ByteBuffer.c
+++ b/limelight-common/ByteBuffer.c
@@ -1,3 +1,4 @@
+#include <netinet/in.h>
 #include "ByteBuffer.h"
 
 void BbInitializeWrappedBuffer(PBYTE_BUFFER buff, char* data, int offset, int length, int byteOrder) {


### PR DESCRIPTION
Is this fix appropriate for the moonlight common C library?