### PR TITLE
Fix skipping first video packet

### DIFF
--- a/limelight-common/VideoDepacketizer.c
+++ b/limelight-common/VideoDepacketizer.c
@@ -38,7 +38,7 @@ void initializeVideoDepacketizer(int pktSize) {
 	waitingForNextSuccessfulFrame = 0;
 	waitingForIdrFrame = 1;
 	gotNextFrameStart = 0;
-	lastPacketInStream = 0;
+	lastPacketInStream = -1;
 	decodingFrame = 0;
 }
 


### PR DESCRIPTION
Because lastPacketInStream is initialized as 0 and the following code in VideoDepacketizer, the first packet, with sequence number 0, is skipped. 
```
// Drop duplicates or re-ordered packets
streamPacketIndex = videoPacket->streamPacketIndex;
if (isBeforeSignedInt((short) streamPacketIndex, (short) (lastPacketInStream + 1), 0)) {
	return;
}
```