### PR TITLE
Reduce audio receive buffer size

### DIFF
--- a/limelight-common/AudioStream.c
+++ b/limelight-common/AudioStream.c
@@ -16,6 +16,7 @@ static PLT_THREAD decoderThread;
 #define RTP_PORT 48000
 
 #define MAX_PACKET_SIZE 100
+#define RTP_RECV_BUFFER 12 * MAX_PACKET_SIZE
 
 typedef struct _QUEUED_AUDIO_PACKET {
 	// data must remain at the front
@@ -214,7 +215,7 @@ int startAudioStream(void) {
     
     AudioCallbacks.init();
 
-	rtpSocket = bindUdpSocket(RemoteAddr.ss_family);
+	rtpSocket = bindUdpSocket(RemoteAddr.ss_family, RTP_RECV_BUFFER);
 	if (rtpSocket == INVALID_SOCKET) {
 		return LastSocketFail();
 	}

--- a/limelight-common/PlatformSockets.c
+++ b/limelight-common/PlatformSockets.c
@@ -21,7 +21,7 @@ void addrToUrlSafeString(struct sockaddr_storage *addr, char* string)
     }
 }
 
-SOCKET bindUdpSocket(int addrfamily) {
+SOCKET bindUdpSocket(int addrfamily, int bufferSize) {
 	SOCKET s;
     struct sockaddr_storage addr;
 	int val;
@@ -54,9 +54,7 @@ SOCKET bindUdpSocket(int addrfamily) {
     setsockopt(s, SOL_SOCKET, SO_NOSIGPIPE, (char* )&val, sizeof(val));
 #endif
 
-    // Set the receive buffer to 64KB by default
-	val = 65536;
-	setsockopt(s, SOL_SOCKET, SO_RCVBUF, (char*) &val, sizeof(val));
+	setsockopt(s, SOL_SOCKET, SO_RCVBUF, (char*) &bufferSize, sizeof(bufferSize));
 
 	return s;
 }

--- a/limelight-common/PlatformSockets.h
+++ b/limelight-common/PlatformSockets.h
@@ -40,5 +40,5 @@ typedef socklen_t SOCKADDR_LEN;
 void addrToUrlSafeString(struct sockaddr_storage *addr, char* string);
 
 SOCKET connectTcpSocket(struct sockaddr_storage *dstaddr, SOCKADDR_LEN addrlen, unsigned short port);
-SOCKET bindUdpSocket(int addrfamily);
+SOCKET bindUdpSocket(int addrfamily, int bufferSize);
 int enableNoDelay(SOCKET s);

--- a/limelight-common/VideoStream.c
+++ b/limelight-common/VideoStream.c
@@ -9,6 +9,8 @@
 #define RTP_PORT 47998
 #define FIRST_FRAME_PORT 47996
 
+#define RTP_RECV_BUFFER 64 * 1024
+
 static RTP_REORDER_QUEUE rtpQueue;
 
 static SOCKET rtpSocket = INVALID_SOCKET;
@@ -181,7 +183,7 @@ int startVideoStream(void* rendererContext, int drFlags) {
 	VideoCallbacks.setup(StreamConfig.width,
 		StreamConfig.height, StreamConfig.fps, rendererContext, drFlags);
     
-	rtpSocket = bindUdpSocket(RemoteAddr.ss_family);
+	rtpSocket = bindUdpSocket(RemoteAddr.ss_family, RTP_RECV_BUFFER);
 	if (rtpSocket == INVALID_SOCKET) {
 		return LastSocketError();
 	}


### PR DESCRIPTION
The UDP audio receive buffer has the same size as the video buffer. This could in some cases lead to delay in the audio.