### PR TITLE
Place slicing behind a flag as not all video decoders support it.

### DIFF
--- a/limelight-common/Limelight.h
+++ b/limelight-common/Limelight.h
@@ -62,6 +62,10 @@ typedef struct _DECODE_UNIT {
 // supports reference frame invalidation. This flag is only valid on video renderers.
 #define CAPABILITY_REFERENCE_FRAME_INVALIDATION 0x2
 
+// If set in the video renderer capabilities field, this flag specifies that the renderer
+// supports slicing to increase decoding performance. This flag is only valid on video renderers.
+#define CAPABILITY_SLICING 0x4
+
 // This callback is invoked to provide details about the video stream and allow configuration of the decoder
 typedef void(*DecoderRendererSetup)(int width, int height, int redrawRate, void* context, int drFlags);
 

--- a/limelight-common/SdpGenerator.c
+++ b/limelight-common/SdpGenerator.c
@@ -139,8 +139,10 @@ static int addGen4Options(PSDP_OPTION *head, char* addrStr) {
     
     err |= addAttributeString(head, "x-nv-video[0].rateControlMode", "4");
     
-    // Use slicing for increased performance on some decoders
-    err |= addAttributeString(head, "x-nv-video[0].videoEncoderSlicesPerFrame", "4");
+	if (VideoCallbacks.capabilities & CAPABILITY_SLICING) {
+		// Use slicing for increased performance on some decoders
+		err |= addAttributeString(head, "x-nv-video[0].videoEncoderSlicesPerFrame", "4");
+	}
     
     return err;
 }


### PR DESCRIPTION
During adding support for a new video decoder in Moonlight Embedded I got issues with slicing. Only by disabling slicing I could get video output. So it would be nice to have it placed behind a flag.