### PR TITLE
Add support for Generation 5 servers (GFE 2.10.2+)

### DIFF
--- a/limelight-common/InputStream.c
+++ b/limelight-common/InputStream.c
@@ -326,7 +326,11 @@ int LiSendMouseMoveEvent(short deltaX, short deltaY) {
 
     holder->packetLength = sizeof(NV_MOUSE_MOVE_PACKET);
     holder->packet.mouseMove.header.packetType = htonl(PACKET_TYPE_MOUSE_MOVE);
-    holder->packet.mouseMove.magic = htonl(MOUSE_MOVE_MAGIC);
+    holder->packet.mouseMove.magic = (MOUSE_MOVE_MAGIC);
+    // On Gen 5 servers, the header code is incremented by one
+    if (ServerMajorVersion >= 5) {
+        holder->packet.mouseMove.magic += 0x01000000;
+    }
     holder->packet.mouseMove.deltaX = htons(deltaX);
     holder->packet.mouseMove.deltaY = htons(deltaY);
 
@@ -355,6 +359,9 @@ int LiSendMouseButtonEvent(char action, int button) {
     holder->packetLength = sizeof(NV_MOUSE_BUTTON_PACKET);
     holder->packet.mouseButton.header.packetType = htonl(PACKET_TYPE_MOUSE_BUTTON);
     holder->packet.mouseButton.action = action;
+    if (ServerMajorVersion >= 5) {
+        holder->packet.mouseButton.action++;
+    }
     holder->packet.mouseButton.button = htonl(button);
 
     err = LbqOfferQueueItem(&packetQueue, holder, &holder->entry);
@@ -432,6 +439,10 @@ static int sendControllerEventInternal(short controllerNumber, short buttonFlags
         holder->packetLength = sizeof(NV_MULTI_CONTROLLER_PACKET);
         holder->packet.multiController.header.packetType = htonl(PACKET_TYPE_MULTI_CONTROLLER);
         holder->packet.multiController.headerA = MC_HEADER_A;
+        // On Gen 5 servers, the header code is decremented by one
+        if (ServerMajorVersion >= 5) {
+            holder->packet.multiController.headerA--;
+        }
         holder->packet.multiController.headerB = MC_HEADER_B;
         holder->packet.multiController.controllerNumber = controllerNumber;
         holder->packet.multiController.midA = MC_ACTIVE_CONTROLLER_FLAGS;
@@ -488,6 +499,10 @@ int LiSendScrollEvent(signed char scrollClicks) {
     holder->packetLength = sizeof(NV_SCROLL_PACKET);
     holder->packet.scroll.header.packetType = htonl(PACKET_TYPE_SCROLL);
     holder->packet.scroll.magicA = MAGIC_A;
+    // On Gen 5 servers, the header code is incremented by one
+    if (ServerMajorVersion >= 5) {
+        holder->packet.scroll.magicA++;
+    }
     holder->packet.scroll.zero1 = 0;
     holder->packet.scroll.zero2 = 0;
     holder->packet.scroll.scrollAmt1 = htons(scrollClicks * 120);

--- a/limelight-common/Limelight-internal.h
+++ b/limelight-common/Limelight-internal.h
@@ -29,7 +29,8 @@ void destroyControlStream(void);
 void requestIdrOnDemand(void);
 void connectionSinkTooSlow(int startFrame, int endFrame);
 void connectionDetectedFrameLoss(int startFrame, int endFrame);
-void connectionReceivedFrame(int frameIndex);
+void connectionReceivedCompleteFrame(int frameIndex);
+void connectionSawFrame(int frameIndex);
 void connectionLostPackets(int lastReceivedPacket, int nextReceivedPacket);
 
 int performRtspHandshake(void);

--- a/limelight-common/RtspConnection.c
+++ b/limelight-common/RtspConnection.c
@@ -299,8 +299,11 @@ int performRtspHandshake(void) {
     if (ServerMajorVersion == 3) {
         rtspClientVersion = 10;
     }
-    else {
+    else if (ServerMajorVersion == 4) {
         rtspClientVersion = 11;
+    }
+    else {
+        rtspClientVersion = 12;
     }
 
     {


### PR DESCRIPTION
I tried to port the Gen5 patch from moonlight-common to moonlight-common-c. Almost everything work except for mouse move.