### PR TITLE
Remove defines of EVP_CIPHER_CTX_new and EVP_CIPHER_CTX_free

### DIFF
--- a/src/InputStream.c
+++ b/src/InputStream.c
@@ -36,14 +36,6 @@ typedef struct _PACKET_HOLDER {
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 #define EVP_CIPHER_CTX_reset(x) EVP_CIPHER_CTX_cleanup(x); EVP_CIPHER_CTX_init(x)
-#define EVP_CIPHER_CTX_free(x) EVP_CIPHER_CTX_cleanup(x)
-
-static EVP_CIPHER_CTX preallocatedCipherContext;
-
-EVP_CIPHER_CTX* EVP_CIPHER_CTX_new() {
-    EVP_CIPHER_CTX_init(&preallocatedCipherContext);
-    return &preallocatedCipherContext;
-}
 #endif
 
 // Initializes the input stream


### PR DESCRIPTION
These functions defined since 0.9.8b