### PR TITLE
vita: Increate thread stack size

### DIFF
--- a/src/Platform.c
+++ b/src/Platform.c
@@ -176,7 +176,7 @@ int PltCreateThread(ThreadEntry entry, void* context, PLT_THREAD* thread) {
         thread->alive = 1;
         thread->context = ctx;
         ctx->thread = thread;
-        thread->handle = sceKernelCreateThread("", ThreadProc, 0, 0x10000, 0, 0, NULL);
+        thread->handle = sceKernelCreateThread("", ThreadProc, 0, 0x40000, 0, 0, NULL);
         if (thread->handle < 0) {
             free(ctx);
             return -1;


### PR DESCRIPTION
readsolomon require large stack memory for the [decode][1]

lazy calucation: 0x105f9
  - dataDecodeMatrix: 255 * 255
  - subShards: 255 * 4
  - outputs:  255 * 4

Fixes #27

[1]: https://github.com/moonlight-stream/moonlight-common-c/blob/9bf8d36/reedsolomon/rs.c#L500-L502