### PR TITLE
Add audio context and flags

### DIFF
--- a/src/AudioStream.c
+++ b/src/AudioStream.c
@@ -280,11 +280,11 @@ void stopAudioStream(void) {
     AudioCallbacks.cleanup();
 }
 
-int startAudioStream(void) {
+int startAudioStream(void* audioContext, int arFlags) {
     int err;
 
     err = AudioCallbacks.init(StreamConfig.audioConfiguration,
-        opusConfigArray[StreamConfig.audioConfiguration]);
+        opusConfigArray[StreamConfig.audioConfiguration], audioContext, arFlags);
     if (err != 0) {
         return err;
     }

--- a/src/Connection.c
+++ b/src/Connection.c
@@ -216,7 +216,8 @@ static int resolveHostName(const char* host)
 
 // Starts the connection to the streaming machine
 int LiStartConnection(PSERVER_INFORMATION serverInfo, PSTREAM_CONFIGURATION streamConfig, PCONNECTION_LISTENER_CALLBACKS clCallbacks,
-    PDECODER_RENDERER_CALLBACKS drCallbacks, PAUDIO_RENDERER_CALLBACKS arCallbacks, void* renderContext, int drFlags) {
+    PDECODER_RENDERER_CALLBACKS drCallbacks, PAUDIO_RENDERER_CALLBACKS arCallbacks, void* renderContext, int drFlags,
+    void* audioContext, int arFlags) {
     int err;
 
     NegotiatedVideoFormat = 0;
@@ -352,7 +353,7 @@ int LiStartConnection(PSERVER_INFORMATION serverInfo, PSTREAM_CONFIGURATION stre
 
     Limelog("Starting audio stream...");
     ListenerCallbacks.stageStarting(STAGE_AUDIO_STREAM_START);
-    err = startAudioStream();
+    err = startAudioStream(audioContext, arFlags);
     if (err != 0) {
         Limelog("Audio stream start failed: %d\n", err);
         ListenerCallbacks.stageFailed(STAGE_AUDIO_STREAM_START, err);

--- a/src/FakeCallbacks.c
+++ b/src/FakeCallbacks.c
@@ -14,7 +14,7 @@ static DECODER_RENDERER_CALLBACKS fakeDrCallbacks = {
     .submitDecodeUnit = fakeDrSubmitDecodeUnit,
 };
 
-static int fakeArInit(int audioConfiguration, POPUS_MULTISTREAM_CONFIGURATION opusConfig) { return 0; }
+static int fakeArInit(int audioConfiguration, POPUS_MULTISTREAM_CONFIGURATION opusConfig, void* context, int arFlags) { return 0; }
 static void fakeArStart(void) {}
 static void fakeArStop(void) {}
 static void fakeArCleanup(void) {}

--- a/src/Limelight-internal.h
+++ b/src/Limelight-internal.h
@@ -56,7 +56,7 @@ void stopVideoStream(void);
 
 void initializeAudioStream(void);
 void destroyAudioStream(void);
-int startAudioStream(void);
+int startAudioStream(void* audioContext, int arFlags);
 void stopAudioStream(void);
 
 int initializeInputStream(void);

--- a/src/Limelight.h
+++ b/src/Limelight.h
@@ -159,7 +159,7 @@ typedef struct _OPUS_MULTISTREAM_CONFIGURATION {
 // This callback initializes the audio renderer. The audio configuration parameter
 // provides the negotiated audio configuration. This may differ from the one
 // specified in the stream configuration. Returns 0 on success, non-zero on failure.
-typedef int(*AudioRendererInit)(int audioConfiguration, POPUS_MULTISTREAM_CONFIGURATION opusConfig);
+typedef int(*AudioRendererInit)(int audioConfiguration, POPUS_MULTISTREAM_CONFIGURATION opusConfig, void* context, int arFlags);
 
 // This callback notifies the decoder that the stream is starting. No audio can be submitted before this callback returns.
 typedef void(*AudioRendererStart)(void);
@@ -260,7 +260,8 @@ void LiInitializeServerInformation(PSERVER_INFORMATION serverInfo);
 // This function is not thread-safe.
 //
 int LiStartConnection(PSERVER_INFORMATION serverInfo, PSTREAM_CONFIGURATION streamConfig, PCONNECTION_LISTENER_CALLBACKS clCallbacks,
-    PDECODER_RENDERER_CALLBACKS drCallbacks, PAUDIO_RENDERER_CALLBACKS arCallbacks, void* renderContext, int drFlags);
+    PDECODER_RENDERER_CALLBACKS drCallbacks, PAUDIO_RENDERER_CALLBACKS arCallbacks, void* renderContext, int drFlags,
+    void* audioContext, int arFlags);
 
 // This function stops streaming. This function is not thread-safe.
 void LiStopConnection(void);


### PR DESCRIPTION
This allows to send a context and flags to the audio renderer just like currently is possible for the video renderer.