### PR TITLE
Use application callback instead of standard error stream for logging

### DIFF
--- a/src/FakeCallbacks.c
+++ b/src/FakeCallbacks.c
@@ -35,6 +35,7 @@ static void fakeClConnectionStarted(void) {}
 static void fakeClConnectionTerminated(long errorCode) {}
 static void fakeClDisplayMessage(const char* message) {}
 static void fakeClDisplayTransientMessage(const char* message) {}
+static void fakeClLogMessage(const char* format, ...) {}
 
 static CONNECTION_LISTENER_CALLBACKS fakeClCallbacks = {
     .stageStarting = fakeClStageStarting,
@@ -44,6 +45,7 @@ static CONNECTION_LISTENER_CALLBACKS fakeClCallbacks = {
     .connectionTerminated = fakeClConnectionTerminated,
     .displayMessage = fakeClDisplayMessage,
     .displayTransientMessage = fakeClDisplayTransientMessage,
+    .logMessage = fakeClLogMessage,
 };
 
 void fixupMissingCallbacks(PDECODER_RENDERER_CALLBACKS* drCallbacks, PAUDIO_RENDERER_CALLBACKS* arCallbacks,
@@ -115,6 +117,9 @@ void fixupMissingCallbacks(PDECODER_RENDERER_CALLBACKS* drCallbacks, PAUDIO_REND
         }
         if ((*clCallbacks)->displayTransientMessage == NULL) {
             (*clCallbacks)->displayTransientMessage = fakeClDisplayTransientMessage;
+        }
+        if ((*clCallbacks)->logMessage == NULL) {
+            (*clCallbacks)->logMessage = fakeClLogMessage;
         }
     }
 }

--- a/src/Limelight.h
+++ b/src/Limelight.h
@@ -232,6 +232,9 @@ typedef void(*ConnListenerDisplayMessage)(const char* message);
 // while streaming
 typedef void(*ConnListenerDisplayTransientMessage)(const char* message);
 
+// This callback is invoked to log debug message
+typedef void(*ConnListenerLogMessage)(const char* format, ...);
+
 typedef struct _CONNECTION_LISTENER_CALLBACKS {
     ConnListenerStageStarting stageStarting;
     ConnListenerStageComplete stageComplete;
@@ -240,6 +243,7 @@ typedef struct _CONNECTION_LISTENER_CALLBACKS {
     ConnListenerConnectionTerminated connectionTerminated;
     ConnListenerDisplayMessage displayMessage;
     ConnListenerDisplayTransientMessage displayTransientMessage;
+    ConnListenerLogMessage logMessage;
 } CONNECTION_LISTENER_CALLBACKS, *PCONNECTION_LISTENER_CALLBACKS;
 
 // Use this function to zero the connection callbacks when allocated on the stack or heap

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -35,20 +35,8 @@
 #include <stdio.h>
 #include "Limelight.h"
 
-#if defined(LC_WINDOWS)
-void LimelogWindows(char* Format, ...);
 #define Limelog(s, ...) \
-    LimelogWindows(s, ##__VA_ARGS__)
-#elif defined(__vita__)
-#define Limelog sceClibPrintf
-#elif defined(LC_ANDROID)
-#include <android/log.h>
-#define Limelog(s, ...) \
-    __android_log_print(ANDROID_LOG_INFO, "moonlight-common-c", s, ##__VA_ARGS__)
-#else
-#define Limelog(s, ...) \
-    fprintf(stderr, s, ##__VA_ARGS__)
-#endif
+    ListenerCallbacks.logMessage(s, ##__VA_ARGS__)
 
 #if defined(LC_WINDOWS)
 #include <crtdbg.h>


### PR DESCRIPTION
Currently all log messages are written to the error stream by default. To get more control of the log messages this patch adds an extra callback in the connection listener to send the log messages to the application for further processing.