### PR TITLE
Reed Solomon Fixes

### DIFF
--- a/src/PlatformSockets.c
+++ b/src/PlatformSockets.c
@@ -87,7 +87,9 @@ int recvUdpSocket(SOCKET s, char* buffer, int size, int useSelect) {
         // socket via SO_RCVTIMEO, so we can avoid a syscall
         // for each packet.
         err = (int)recv(s, buffer, size, 0);
-        if (err < 0 && LastSocketError() == EWOULDBLOCK) {
+        if (err < 0 &&
+                (LastSocketError() == EWOULDBLOCK ||
+                 LastSocketError() == EAGAIN)) {
             // Return 0 for timeout
             return 0;
         }

--- a/src/PlatformSockets.h
+++ b/src/PlatformSockets.h
@@ -11,6 +11,7 @@
 
 #define SHUT_RDWR SD_BOTH
 #define EWOULDBLOCK WSAEWOULDBLOCK
+#define EAGAIN WSAEWOULDBLOCK
 
 typedef int SOCK_RET;
 typedef int SOCKADDR_LEN;


### PR DESCRIPTION
- Macro safety: Added parentheses around macro params
- Swap _Alloca for _Malloca for the security benefits it provides. Also, these are well-defined functions in #malloc.h. No need for rolling our own definitions.
- Check for some errors
- Do some input vailidation
- Remove asserts because they only work in debug environments. Replace them with runtime checks.
- Some stylistic fixes.
- Use goto exit instead of randomly returning.

Verified it still builds.