### PR TITLE
vita: Restore select call on the VITA system

### DIFF
--- a/src/PlatformSockets.h
+++ b/src/PlatformSockets.h
@@ -32,7 +32,24 @@ typedef int SOCKADDR_LEN;
 #include <netdb.h>
 #include <errno.h>
 #include <signal.h>
+#if defined(__vita__)
+#define POLLIN      0x0001
+#define POLLPRI     0x0002
+#define POLLOUT     0x0004
+#define POLLERR     0x0008
+#define POLLRDNORM  0x0040
+#define POLLWRNORM  POLLOUT
+#define POLLRDBAND  0x0080
+#define POLLWRBAND  0x0100
+
+struct pollfd {
+    int fd;
+    short events;
+    short revents;
+};
+#else
 #include <poll.h>
+#endif
 
 #define ioctlsocket ioctl
 #define LastSocketError() errno


### PR DESCRIPTION
this platform doesn't support `poll` yet.
temporary restore the `select` call until implement it.