### PR TITLE
Added support of HEVC encoded by AMF toolkit from AMD

### DIFF
--- a/src/VideoDepacketizer.c
+++ b/src/VideoDepacketizer.c
@@ -230,7 +230,8 @@ static bool isIdrFrameStart(PBUFFER_DESC buffer) {
     return getSpecialSeq(buffer, &specialSeq) &&
         isSeqFrameStart(&specialSeq) &&
         (specialSeq.data[specialSeq.offset + specialSeq.length] == 0x67 || // H264 SPS
-         specialSeq.data[specialSeq.offset + specialSeq.length] == 0x40); // H265 VPS
+         specialSeq.data[specialSeq.offset + specialSeq.length] == 0x40 || // H265 VPS
+         specialSeq.data[specialSeq.offset + specialSeq.length + 7] == 0x40); // HEVC encoded by AMF
 }
 
 // Reassemble the frame with the given frame number


### PR DESCRIPTION
I working on support of AMD hw encoding in openstream app and this fix needs for handling HEVC encoded by hw encoder.

![hevc](https://user-images.githubusercontent.com/1980835/112411286-d8d50b80-8d46-11eb-8543-ea98bd4c9291.png)