### PR TITLE
Added unicode input event

### DIFF
--- a/src/Input.h
+++ b/src/Input.h
@@ -25,6 +25,14 @@ typedef struct _NV_KEYBOARD_PACKET {
     short zero2;
 } NV_KEYBOARD_PACKET, *PNV_KEYBOARD_PACKET;
 
+#define UNICODE_EVENT_MAGIC 0x17
+#define UNICODE_EVENT_MAX_COUNT 32
+typedef struct _NV_UNICODE_PACKET {
+    unsigned int size;
+    int magic;
+    char text[UNICODE_EVENT_MAX_COUNT];
+} NV_UNICODE_PACKET, *PNV_UNICODE_PACKET;
+
 #define PACKET_TYPE_REL_MOUSE_MOVE 0x08
 #define MOUSE_MOVE_REL_MAGIC 0x06
 typedef struct _NV_REL_MOUSE_MOVE_PACKET {

--- a/src/Input.h
+++ b/src/Input.h
@@ -30,7 +30,7 @@ typedef struct _NV_KEYBOARD_PACKET {
 typedef struct _NV_UNICODE_PACKET {
     unsigned int size;
     int magic;
-    char text[UNICODE_EVENT_MAX_COUNT];
+    char text[UNICODE_EVENT_MAX_COUNT + 1];
 } NV_UNICODE_PACKET, *PNV_UNICODE_PACKET;
 
 #define PACKET_TYPE_REL_MOUSE_MOVE 0x08

--- a/src/Input.h
+++ b/src/Input.h
@@ -25,12 +25,12 @@ typedef struct _NV_KEYBOARD_PACKET {
     short zero2;
 } NV_KEYBOARD_PACKET, *PNV_KEYBOARD_PACKET;
 
-#define UNICODE_EVENT_MAGIC 0x17
-#define UNICODE_EVENT_MAX_COUNT 32
+#define UTF8_TEXT_EVENT_MAGIC 0x17
+#define UTF8_TEXT_EVENT_MAX_COUNT 32
 typedef struct _NV_UNICODE_PACKET {
     unsigned int size;
     int magic;
-    char text[UNICODE_EVENT_MAX_COUNT + 1];
+    char text[UTF8_TEXT_EVENT_MAX_COUNT];
 } NV_UNICODE_PACKET, *PNV_UNICODE_PACKET;
 
 #define PACKET_TYPE_REL_MOUSE_MOVE 0x08

--- a/src/Limelight.h
+++ b/src/Limelight.h
@@ -519,7 +519,9 @@ int LiSendMouseButtonEvent(char action, int button);
 #define MODIFIER_META 0x08
 int LiSendKeyboardEvent(short keyCode, char keyAction, char modifiers);
 
-int LiSendUnicodeEvent(const char *text, unsigned int length);
+// This function queues an UTF-8 encoded text to be sent to the remote server.
+// Currently maximum length is 32 bytes.
+int LiSendUtf8TextEvent(const char *text, unsigned int length);
 
 // Button flags
 #define A_FLAG     0x1000

--- a/src/Limelight.h
+++ b/src/Limelight.h
@@ -519,6 +519,8 @@ int LiSendMouseButtonEvent(char action, int button);
 #define MODIFIER_META 0x08
 int LiSendKeyboardEvent(short keyCode, char keyAction, char modifiers);
 
+int LiSendUnicodeEvent(const char *text, unsigned int length);
+
 // Button flags
 #define A_FLAG     0x1000
 #define B_FLAG     0x2000


### PR DESCRIPTION
Added `LiSendUnicodeEvent` function - this function can send any text encoded with UTF-8 to host, up to 32 bytes.