### PR TITLE
Add workaround for missing last byte in RTSP message

### DIFF
--- a/src/RtspParser.c
+++ b/src/RtspParser.c
@@ -175,6 +175,16 @@ int parseRtspMessage(PRTSP_MESSAGE msg, char* rtspMessage, int length) {
 
                     break;
                 }
+                else if (startsWith(endCheck, "\n\r") && endCheck[2] == '\0') {
+                    // Previous `if` statement already handle situation when two bytes are missing.
+                    // This is the workaround for the same problem, but for only one byte missing.
+                    // Sometimes on android emulators last byte or two bytes are missing.
+                    // This is link to this bug in Goggle Issue Tracker:
+                    // https://issuetracker.google.com/issues/150758736?pli=1
+                    messageEnded = true;
+
+                    break;
+                }
                 else if (startsWith(endCheck, "\n\r\n")) {
                     // We've encountered the end of the message - mark it thus
                     messageEnded = true;


### PR DESCRIPTION
Sometimes on android devices last byte is missing. This is link to this bug in Goggle Issue Tracker:
https://issuetracker.google.com/issues/150758736?pli=1

This is one of the comments from the link above:
> Still present in API level 33.
>
> This occurs extremely frequently for me as my app communicates with a tiny daemon with a simplistic implementation where > every request is done over a new TCP connection.
>
> A lot of the responses from the daemon are just the JSON data {"success":true} and the closing curly brace is cut off very frequently. Maybe it's more common with small payloads.
> 
> I'm now working around it simply by having the daemon send a superfluous newline after the JSON object, which shouldn't bother the JSON reader on the client side.
>
> A bit of venting:
>
> It was a complete nightmare to debug and verify this in my codebase because my brain would just completely reject the notion that a TCP connection could ever just not be reliable. It's like observing the rules of the universe break apart, it must be an illusion somehow, there must be another explanation! But no, a TCP socket implementation is just eating my bytes. It instills a sense of cosmic dread and horror when I think too much about it.


The problem has been around for years and Google is doing nothing about it. Therefore, a workaround must be used.
moonlight-common-c already has a workaround for the two bytes missing at this lines:
https://github.com/moonlight-stream/moonlight-common-c/blob/284840bde75c0e30dd72aaa5e4e136dedf084ee1/src/RtspParser.c#L172-L177

But one missing byte must also be handled.

Please note that I usually see this issue on an android emulator and have never seen it on a real device.
