### PR TITLE
Improve 3DS Reliability

### DIFF
--- a/src/Platform.c
+++ b/src/Platform.c
@@ -14,6 +14,10 @@ struct thread_context {
 #endif
 };
 
+#ifdef __3DS__
+static int n3ds_thread_priority = 0x30;
+#endif
+
 static int activeThreads = 0;
 static int activeMutexes = 0;
 static int activeEvents = 0;
@@ -279,13 +283,11 @@ int PltCreateThread(const char* name, ThreadEntry entry, void* context, PLT_THRE
     OSResumeThread(&thread->thread);
 #elif defined(__3DS__)
     {
-        s32 priority = 0x30;
-        size_t stack_size = 1024 * 1024;
-        svcGetThreadPriority(&priority, CUR_THREAD_HANDLE);
+        size_t stack_size = 0x40000;
         thread->thread = threadCreate(ThreadProc,
                                     ctx,
                                     stack_size,
-                                    priority,
+                                    n3ds_thread_priority,
                                     -1,
                                     false);
         if (thread->thread == NULL) {
@@ -494,6 +496,9 @@ int initializePlatform(void) {
         return err;
     }
 
+#ifdef __3DS__
+    svcGetThreadPriority(&n3ds_thread_priority, CUR_THREAD_HANDLE);
+#endif
     enterLowLatencyMode();
 
     return 0;

--- a/src/Platform.c
+++ b/src/Platform.c
@@ -14,10 +14,6 @@ struct thread_context {
 #endif
 };
 
-#ifdef __3DS__
-static int n3ds_thread_priority = 0x30;
-#endif
-
 static int activeThreads = 0;
 static int activeMutexes = 0;
 static int activeEvents = 0;
@@ -284,10 +280,12 @@ int PltCreateThread(const char* name, ThreadEntry entry, void* context, PLT_THRE
 #elif defined(__3DS__)
     {
         size_t stack_size = 0x40000;
+        s32 priority = 0x30;
+        svcGetThreadPriority(&priority, CUR_THREAD_HANDLE);
         thread->thread = threadCreate(ThreadProc,
                                     ctx,
                                     stack_size,
-                                    n3ds_thread_priority,
+                                    priority,
                                     -1,
                                     false);
         if (thread->thread == NULL) {
@@ -496,9 +494,6 @@ int initializePlatform(void) {
         return err;
     }
 
-#ifdef __3DS__
-    svcGetThreadPriority(&n3ds_thread_priority, CUR_THREAD_HANDLE);
-#endif
     enterLowLatencyMode();
 
     return 0;


### PR DESCRIPTION
## Overview
This MR improves moonlight's reliability on the 3DS, mostly around socket connections. Since adding these changes, the 3DS app went from crashing within minutes of connecting to the server to being able to hold a stable connection with the host for hours on end.

## Changelog

- Simplifies thread priority setup
- Sets a max socket buffer size of 0x20000 for the 3DS
- Fixes a bug with polling timeouts taking longer than intended
- Removes 3DS global socket definition