### PR TITLE
Implement detached threads

### DIFF
--- a/src/Connection.c
+++ b/src/Connection.c
@@ -175,8 +175,8 @@ static void ClInternalConnectionTerminated(int errorCode)
         LC_ASSERT(err == 0);
     }
 
-    // Close the thread handle since we can never wait on it
-    PltCloseThread(&terminationCallbackThread);
+    // Detach the thread since we never wait on it
+    PltDetachThread(&terminationCallbackThread);
 }
 
 static bool parseRtspPortNumberFromUrl(const char* rtspSessionUrl, uint16_t* port)

--- a/src/Platform.c
+++ b/src/Platform.c
@@ -198,7 +198,6 @@ void PltJoinThread(PLT_THREAD* thread) {
     OSJoinThread(&thread->thread, NULL);
 #elif defined(__3DS__)
     threadJoin(thread->thread, U64_MAX);
-    threadFree(thread->thread);
 #else
     pthread_join(thread->thread, NULL);
 #endif
@@ -230,6 +229,12 @@ void PltCloseThread(PLT_THREAD* thread) {
     CloseHandle(thread->handle);
 #elif defined(__vita__)
     sceKernelDeleteThread(thread->handle);
+#elif defined(__WIIU__)
+    // Thread is automatically closed after join
+#elif defined(__3DS__)
+    threadFree(thread->thread);
+#else
+    // Thread is automatically closed after join
 #endif
 }
 

--- a/src/Platform.c
+++ b/src/Platform.c
@@ -204,6 +204,26 @@ void PltJoinThread(PLT_THREAD* thread) {
 #endif
 }
 
+void PltDetachThread(PLT_THREAD* thread)
+{
+    // Assume detached threads are no longer active
+    activeThreads--;
+
+#if defined(LC_WINDOWS)
+    // According MSDN:
+    // "Closing a thread handle does not terminate the associated thread or remove the thread object."
+    CloseHandle(thread->handle);
+#elif defined(__vita__)
+    sceKernelDeleteThread(thread->handle);
+#elif defined(__WIIU__)
+    OSDetachThread(&thread->thread);
+#elif defined(__3DS__)
+    threadDetach(thread->thread);
+#else
+    pthread_detach(thread->thread);
+#endif
+}
+
 void PltCloseThread(PLT_THREAD* thread) {
     activeThreads--;
 #if defined(LC_WINDOWS)

--- a/src/PlatformThreads.h
+++ b/src/PlatformThreads.h
@@ -66,6 +66,7 @@ void PltCloseThread(PLT_THREAD* thread);
 void PltInterruptThread(PLT_THREAD* thread);
 bool PltIsThreadInterrupted(PLT_THREAD* thread);
 void PltJoinThread(PLT_THREAD* thread);
+void PltDetachThread(PLT_THREAD* thread);
 
 int PltCreateEvent(PLT_EVENT* event);
 void PltCloseEvent(PLT_EVENT* event);


### PR DESCRIPTION
The `AsyncTerm` thread is never joined but its handle is immediately closed. This works fine on Windows, but causes issues on other platforms where threads need to be explicitly detached if never joined (pthread, wiiu).

This adds a new `PltDetachThread` function, which can be used instead of `PltCloseThread` to explictly detach a thread, requiring it to no longer be closed.

Note that this hasn't been tested on any platforms other than Wii U.
The vita code needs needs to be checked, since I'm not sure if `sceKernelDeleteThread` behaves like Windows (detaching the thread) or immediately terminating the thread when called.