### PR TITLE
feat: increase first frame timeout

### DIFF
--- a/src/VideoStream.c
+++ b/src/VideoStream.c
@@ -1,7 +1,7 @@
 #include "Limelight-internal.h"
 
 #define FIRST_FRAME_MAX 1500
-#define FIRST_FRAME_TIMEOUT_SEC 10
+#define FIRST_FRAME_TIMEOUT_SEC 60
 
 #define FIRST_FRAME_PORT 47996
 


### PR DESCRIPTION
This small change relaxes the timeout for the first frame to come from the remote hosts which take long time to initialize a videostream.

This is primarily targets use case when using Windows Hyper-V GPU Partitioning. 
For some unknown reason when streaming using Sunshine it takes quite some time for the first frame to actually be sent into the stream.

Closes: #93 

References:
https://www.reddit.com/r/LizardByte/comments/13n1mn6/sunshine_moonlight_on_hypervvm_with_gpupv_results/
https://github.com/itsmikethetech/Virtual-Display-Driver/issues/9#issuecomment-1865058384
https://www.reddit.com/r/cloudygamer/comments/ubjej0/if_you_are_experiencing_the_black_screen_issue/
https://www.reddit.com/r/cloudygamer/comments/zunij1/sunshine_is_giving_me_a_blank_screen_on_a_hyperv/
https://www.reddit.com/r/LizardByte/comments/1ec8n65/enhancedgpupv_with_sunshinemoonlight_and_virtual/
