### PR TITLE
Guard against rtsp response with no content

### DIFF
--- a/src/RtspConnection.c
+++ b/src/RtspConnection.c
@@ -1059,6 +1059,12 @@ int performRtspHandshake(PSERVER_INFORMATION serverInfo) {
             ret = response.message.response.statusCode;
             goto Exit;
         }
+
+        if (!response.payload) {
+            Limelog("RTSP DESCRIBE no content in response\n");
+            ret = -1;
+            goto Exit;
+        }
         
         if ((StreamConfig.supportedVideoFormats & VIDEO_FORMAT_MASK_AV1) && strstr(response.payload, "AV1/90000")) {
             if ((serverInfo->serverCodecModeSupport & SCM_AV1_HIGH10_444) && (StreamConfig.supportedVideoFormats & VIDEO_FORMAT_AV1_HIGH10_444)) {


### PR DESCRIPTION
Header-only rtsp response leads to a crash since `strstr()` function doesn't guard against `nullptr`.
![rtsp_no_resp](https://github.com/user-attachments/assets/3ed8ecd9-80c1-4ccd-984c-ce378037eb7d)
