### PR TITLE
Use atomic variables for ConnectionInterrupted and LBQ currentSize

### DIFF
--- a/src/Connection.c
+++ b/src/Connection.c
@@ -1,5 +1,7 @@
 #include "Limelight-internal.h"
 
+#include <stdatomic.h>
+
 static int stage = STAGE_NONE;
 static ConnListenerConnectionTerminated originalTerminationCallback;
 static bool alreadyTerminated;
@@ -17,7 +19,7 @@ CONNECTION_LISTENER_CALLBACKS ListenerCallbacks;
 DECODER_RENDERER_CALLBACKS VideoCallbacks;
 AUDIO_RENDERER_CALLBACKS AudioCallbacks;
 int NegotiatedVideoFormat;
-volatile bool ConnectionInterrupted;
+volatile atomic_bool ConnectionInterrupted = ATOMIC_VAR_INIT(false);
 bool HighQualitySurroundSupported;
 bool HighQualitySurroundEnabled;
 OPUS_MULTISTREAM_CONFIGURATION NormalQualityOpusConfig;

--- a/src/Limelight-internal.h
+++ b/src/Limelight-internal.h
@@ -24,7 +24,7 @@ extern CONNECTION_LISTENER_CALLBACKS ListenerCallbacks;
 extern DECODER_RENDERER_CALLBACKS VideoCallbacks;
 extern AUDIO_RENDERER_CALLBACKS AudioCallbacks;
 extern int NegotiatedVideoFormat;
-extern volatile bool ConnectionInterrupted;
+extern volatile atomic_bool ConnectionInterrupted;
 extern bool HighQualitySurroundSupported;
 extern bool HighQualitySurroundEnabled;
 extern OPUS_MULTISTREAM_CONFIGURATION NormalQualityOpusConfig;

--- a/src/LinkedBlockingQueue.c
+++ b/src/LinkedBlockingQueue.c
@@ -116,7 +116,7 @@ int LbqOfferQueueItem(PLINKED_BLOCKING_QUEUE queueHead, void* data, PLINKED_BLOC
         queueHead->tail = entry;
     }
 
-    queueHead->currentSize++;
+    atomic_fetch_add(&queueHead->currentSize, 1);
     queueHead->lifetimeSize++;
 
     PltUnlockMutex(&queueHead->mutex);
@@ -180,7 +180,7 @@ int LbqPollQueueElement(PLINKED_BLOCKING_QUEUE queueHead, void** data) {
 
     entry = queueHead->head;
     queueHead->head = entry->flink;
-    queueHead->currentSize--;
+    atomic_fetch_add(&queueHead->currentSize, -1);
     if (queueHead->head == NULL) {
         LC_ASSERT(queueHead->currentSize == 0);
         queueHead->tail = NULL;
@@ -231,7 +231,7 @@ int LbqWaitForQueueElement(PLINKED_BLOCKING_QUEUE queueHead, void** data) {
 
     entry = queueHead->head;
     queueHead->head = entry->flink;
-    queueHead->currentSize--;
+    atomic_fetch_add(&queueHead->currentSize, -1);
     if (queueHead->head == NULL) {
         LC_ASSERT(queueHead->currentSize == 0);
         queueHead->tail = NULL;

--- a/src/LinkedBlockingQueue.h
+++ b/src/LinkedBlockingQueue.h
@@ -3,6 +3,8 @@
 #include "Platform.h"
 #include "PlatformThreads.h"
 
+#include <stdatomic.h>
+
 #define LBQ_SUCCESS 0
 #define LBQ_INTERRUPTED 1
 #define LBQ_BOUND_EXCEEDED 2
@@ -21,7 +23,7 @@ typedef struct _LINKED_BLOCKING_QUEUE {
     PLINKED_BLOCKING_QUEUE_ENTRY head;
     PLINKED_BLOCKING_QUEUE_ENTRY tail;
     int sizeBound;
-    int currentSize;
+    atomic_int currentSize;
     int lifetimeSize;
     bool shutdown;
     bool draining;


### PR DESCRIPTION
These were the only two variables reported by clang's -fsanitize=thread. I was testing the iOS app in Xcode and didn't test that many code paths, but these 2 were straightforward to fix.

For as often as currentSize gets touched, it's never caused a problem for me, so I doubt these have ever caused crashes for anyone. Maybe technically, in theory they could have.