### PR TITLE
Protocol extension: DualSense adaptive trigger support

### DIFF
--- a/src/ControlStream.c
+++ b/src/ControlStream.c
@@ -72,9 +72,9 @@ typedef struct _QUEUED_ASYNC_CALLBACK {
              * 0x04 - Right trigger
              * 0x08 - Left trigger
              */
-            uint8_t event_flags;
-            uint8_t type_left;
-            uint8_t type_right;
+            uint8_t eventFlags;
+            uint8_t typeLeft;
+            uint8_t typeRight;
             // arrays of size DS_EFFECT_PAYLOAD_SIZE
             // this is an opaque payload that will be read directly from the joypad and set as is to the client controller
             // if you are curious about the actual data, there's some rationale in
@@ -980,9 +980,9 @@ static void asyncCallbackThreadFunc(void* context) {
             break;
         case IDX_DS_ADAPTIVE_TRIGGERS:
             ListenerCallbacks.setAdaptiveTriggers(queuedCb->data.dsAdaptiveTrigger.controllerNumber,
-                                                  queuedCb->data.dsAdaptiveTrigger.event_flags,
-                                                  queuedCb->data.dsAdaptiveTrigger.type_left,
-                                                  queuedCb->data.dsAdaptiveTrigger.type_right,
+                                                  queuedCb->data.dsAdaptiveTrigger.eventFlags,
+                                                  queuedCb->data.dsAdaptiveTrigger.typeLeft,
+                                                  queuedCb->data.dsAdaptiveTrigger.typeRight,
                                                   queuedCb->data.dsAdaptiveTrigger.left,
                                                   queuedCb->data.dsAdaptiveTrigger.right);
             break;
@@ -1055,9 +1055,9 @@ static void queueAsyncCallback(PNVCTL_ENET_PACKET_HEADER_V1 ctlHdr, int packetLe
     }
     else if (ctlHdr->type == packetTypes[IDX_DS_ADAPTIVE_TRIGGERS]){
         BbGet16(&bb, &queuedCb->data.dsAdaptiveTrigger.controllerNumber);
-        BbGet8(&bb, &queuedCb->data.dsAdaptiveTrigger.event_flags);
-        BbGet8(&bb, &queuedCb->data.dsAdaptiveTrigger.type_left);
-        BbGet8(&bb, &queuedCb->data.dsAdaptiveTrigger.type_right);
+        BbGet8(&bb, &queuedCb->data.dsAdaptiveTrigger.eventFlags);
+        BbGet8(&bb, &queuedCb->data.dsAdaptiveTrigger.typeLeft);
+        BbGet8(&bb, &queuedCb->data.dsAdaptiveTrigger.typeRight);
 
         for(int i = 0; i < DS_EFFECT_PAYLOAD_SIZE; i++) {
             BbGet8(&bb, &queuedCb->data.dsAdaptiveTrigger.left[i]);

--- a/src/ControlStream.c
+++ b/src/ControlStream.c
@@ -207,6 +207,7 @@ static const short packetTypesGen7Enc[] = {
     0x5500, // Rumble triggers (Sunshine protocol extension)
     0x5501, // Set motion event (Sunshine protocol extension)
     0x5502, // Set RGB LED (Sunshine protocol extension)
+    0x5503, // Set Adaptive Triggers (Sunshine protocol extension)
 };
 
 static const char requestIdrFrameGen3[] = { 0, 0 };

--- a/src/FakeCallbacks.c
+++ b/src/FakeCallbacks.c
@@ -39,7 +39,7 @@ static void fakeClConnectionStatusUpdate(int connectionStatus) {}
 static void fakeClSetHdrMode(bool enabled) {}
 static void fakeClRumbleTriggers(uint16_t controllerNumber, uint16_t leftTriggerMotor, uint16_t rightTriggerMotor) {}
 static void fakeClSetMotionEventState(uint16_t controllerNumber, uint8_t motionType, uint16_t reportRateHz) {}
-static void fakeClSetAdaptiveTriggers(uint16_t controllerNumber, uint8_t event_flags, uint8_t type_left, uint8_t type_right, uint8_t *left, uint8_t *right) {};
+static void fakeClSetAdaptiveTriggers(uint16_t controllerNumber, uint8_t eventFlags, uint8_t typeLeft, uint8_t typeRight, uint8_t *left, uint8_t *right) {};
 static void fakeClSetControllerLED(uint16_t controllerNumber, uint8_t r, uint8_t g, uint8_t b) {}
 
 static CONNECTION_LISTENER_CALLBACKS fakeClCallbacks = {

--- a/src/FakeCallbacks.c
+++ b/src/FakeCallbacks.c
@@ -39,6 +39,7 @@ static void fakeClConnectionStatusUpdate(int connectionStatus) {}
 static void fakeClSetHdrMode(bool enabled) {}
 static void fakeClRumbleTriggers(uint16_t controllerNumber, uint16_t leftTriggerMotor, uint16_t rightTriggerMotor) {}
 static void fakeClSetMotionEventState(uint16_t controllerNumber, uint8_t motionType, uint16_t reportRateHz) {}
+static void fakeClSetAdaptiveTriggers(uint16_t controllerNumber, uint8_t type_left, uint8_t type_right, uint8_t *left, uint8_t *right) {};
 static void fakeClSetControllerLED(uint16_t controllerNumber, uint8_t r, uint8_t g, uint8_t b) {}
 
 static CONNECTION_LISTENER_CALLBACKS fakeClCallbacks = {
@@ -54,6 +55,7 @@ static CONNECTION_LISTENER_CALLBACKS fakeClCallbacks = {
     .rumbleTriggers = fakeClRumbleTriggers,
     .setMotionEventState = fakeClSetMotionEventState,
     .setControllerLED = fakeClSetControllerLED,
+    .setAdaptiveTriggers = fakeClSetAdaptiveTriggers,
 };
 
 void fixupMissingCallbacks(PDECODER_RENDERER_CALLBACKS* drCallbacks, PAUDIO_RENDERER_CALLBACKS* arCallbacks,
@@ -140,6 +142,9 @@ void fixupMissingCallbacks(PDECODER_RENDERER_CALLBACKS* drCallbacks, PAUDIO_REND
         }
         if ((*clCallbacks)->setControllerLED == NULL) {
             (*clCallbacks)->setControllerLED = fakeClSetControllerLED;
+        }
+        if ((*clCallbacks)->setAdaptiveTriggers == NULL) {
+            (*clCallbacks)->setAdaptiveTriggers = fakeClSetAdaptiveTriggers;
         }
     }
 }

--- a/src/FakeCallbacks.c
+++ b/src/FakeCallbacks.c
@@ -39,7 +39,7 @@ static void fakeClConnectionStatusUpdate(int connectionStatus) {}
 static void fakeClSetHdrMode(bool enabled) {}
 static void fakeClRumbleTriggers(uint16_t controllerNumber, uint16_t leftTriggerMotor, uint16_t rightTriggerMotor) {}
 static void fakeClSetMotionEventState(uint16_t controllerNumber, uint8_t motionType, uint16_t reportRateHz) {}
-static void fakeClSetAdaptiveTriggers(uint16_t controllerNumber, uint8_t type_left, uint8_t type_right, uint8_t *left, uint8_t *right) {};
+static void fakeClSetAdaptiveTriggers(uint16_t controllerNumber, uint8_t event_flags, uint8_t type_left, uint8_t type_right, uint8_t *left, uint8_t *right) {};
 static void fakeClSetControllerLED(uint16_t controllerNumber, uint8_t r, uint8_t g, uint8_t b) {}
 
 static CONNECTION_LISTENER_CALLBACKS fakeClCallbacks = {

--- a/src/Limelight.h
+++ b/src/Limelight.h
@@ -474,7 +474,7 @@ typedef void(*ConnListenerSetMotionEventState)(uint16_t controllerNumber, uint8_
 #define DS_EFFECT_PAYLOAD_SIZE 10
 #define DS_EFFECT_RIGHT_TRIGGER 0x04
 #define DS_EFFECT_LEFT_TRIGGER 0x08
-typedef void(*ConnListenerSetAdaptiveTriggers)(uint16_t controllerNumber, uint8_t event_flags, uint8_t type_left, uint8_t type_right, uint8_t *left, uint8_t *right);
+typedef void(*ConnListenerSetAdaptiveTriggers)(uint16_t controllerNumber, uint8_t eventFlags, uint8_t typeLeft, uint8_t typeRight, uint8_t *left, uint8_t *right);
 
 // This callback is invoked to set a controller's RGB LED (if present).
 typedef void(*ConnListenerSetControllerLED)(uint16_t controllerNumber, uint8_t r, uint8_t g, uint8_t b);

--- a/src/Limelight.h
+++ b/src/Limelight.h
@@ -472,7 +472,9 @@ typedef void(*ConnListenerSetMotionEventState)(uint16_t controllerNumber, uint8_
 // This callback is invoked to notify the client of a change in the dualsense
 // adaptive trigger configuration.
 #define DS_EFFECT_PAYLOAD_SIZE 10
-typedef void(*ConnListenerSetAdaptiveTriggers)(uint16_t controllerNumber, uint8_t type_left, uint8_t type_right, uint8_t *left, uint8_t *right);
+#define DS_EFFECT_RIGHT_TRIGGER 0x04
+#define DS_EFFECT_LEFT_TRIGGER 0x08
+typedef void(*ConnListenerSetAdaptiveTriggers)(uint16_t controllerNumber, uint8_t event_flags, uint8_t type_left, uint8_t type_right, uint8_t *left, uint8_t *right);
 
 // This callback is invoked to set a controller's RGB LED (if present).
 typedef void(*ConnListenerSetControllerLED)(uint16_t controllerNumber, uint8_t r, uint8_t g, uint8_t b);

--- a/src/Limelight.h
+++ b/src/Limelight.h
@@ -69,7 +69,7 @@ typedef struct _STREAM_CONFIGURATION {
     // Specifies the channel configuration of the audio stream.
     // See AUDIO_CONFIGURATION constants and MAKE_AUDIO_CONFIGURATION() below.
     int audioConfiguration;
-    
+
     // Specifies the mask of supported video formats.
     // See VIDEO_FORMAT constants below.
     int supportedVideoFormats;
@@ -469,6 +469,11 @@ typedef void(*ConnListenerRumbleTriggers)(uint16_t controllerNumber, uint16_t le
 // If reportRateHz is 0, the host is asking for motion event reporting to stop.
 typedef void(*ConnListenerSetMotionEventState)(uint16_t controllerNumber, uint8_t motionType, uint16_t reportRateHz);
 
+// This callback is invoked to notify the client of a change in the dualsense
+// adaptive trigger configuration.
+#define DS_EFFECT_PAYLOAD_SIZE 10
+typedef void(*ConnListenerSetAdaptiveTriggers)(uint16_t controllerNumber, uint8_t type_left, uint8_t type_right, uint8_t *left, uint8_t *right);
+
 // This callback is invoked to set a controller's RGB LED (if present).
 typedef void(*ConnListenerSetControllerLED)(uint16_t controllerNumber, uint8_t r, uint8_t g, uint8_t b);
 
@@ -485,6 +490,7 @@ typedef struct _CONNECTION_LISTENER_CALLBACKS {
     ConnListenerRumbleTriggers rumbleTriggers;
     ConnListenerSetMotionEventState setMotionEventState;
     ConnListenerSetControllerLED setControllerLED;
+    ConnListenerSetAdaptiveTriggers setAdaptiveTriggers;
 } CONNECTION_LISTENER_CALLBACKS, *PCONNECTION_LISTENER_CALLBACKS;
 
 // Use this function to zero the connection callbacks when allocated on the stack or heap
@@ -512,10 +518,10 @@ void LiInitializeConnectionCallbacks(PCONNECTION_LISTENER_CALLBACKS clCallbacks)
 typedef struct _SERVER_INFORMATION {
     // Server host name or IP address in text form
     const char* address;
-    
+
     // Text inside 'appversion' tag in /serverinfo
     const char* serverInfoAppVersion;
-    
+
     // Text inside 'GfeVersion' tag in /serverinfo (if present)
     const char* serverInfoGfeVersion;
 


### PR DESCRIPTION
This is part of a series of PRs:

## Moonlight client
 - https://github.com/moonlight-stream/moonlight-common-c/pull/102 to extend the Moonlight protocol for this new event
 - https://github.com/moonlight-stream/moonlight-qt/pull/1561 requires the changes in `moonlight-common-c` and exposes the adaptive trigger events via SDL

## Sunshine server
 - https://github.com/games-on-whales/inputtino/pull/26 to expose the adaptive triggers events in Linux
 - https://github.com/LizardByte/Sunshine/pull/3738  requires the changes in `moonlight-common-c` and `inputtino` and delivers the adaptive trigger events to Moonlight clients

https://github.com/user-attachments/assets/c403a181-bae7-4b79-a5b6-7278f5bba97e