### PR TITLE
ci(build): enable x86 for windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # TODO: Win32 build cannot find OpenSSL
-          # - os: windows-latest
-          #   cmake_args: -A Win32
+          # TODO: arm build fails to link
+          # - os: windows-11-arm
+          #   cmake_args: -A ARM64 -DOPENSSL_ROOT_DIR="C:\OpenSSL" -DOPENSSL_INCLUDE_DIR="C:\OpenSSL\include\arm64"
+          #   install_win_openssl: true
+          - os: windows-latest
+            cmake_args: -A Win32 -DOPENSSL_ROOT_DIR="C:\OpenSSL" -DOPENSSL_INCLUDE_DIR="C:\OpenSSL\include\x86"
+            install_win_openssl: true
           - os: windows-latest
             cmake_args: -A x64
           - os: macos-latest
@@ -55,10 +59,34 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install Windows OpenSSL
+        if: matrix.install_win_openssl
+        run: |
+          # https://slproweb.com/products/Win32OpenSSL.html
+          Write-Host "Downloading OpenSSL installer..."
+          $url = "https://slproweb.com/download/WinUniversalOpenSSL-3_5_0.exe"
+          $output = Join-Path -Path $env:TEMP -ChildPath "openssl.exe"
+          Invoke-WebRequest -Uri $url -OutFile $output
+
+          Write-Host "Download complete. Starting installation..."
+          Start-Process `
+            -FilePath $output `
+            -ArgumentList "/SP", "/SILENT", "/ALLUSERS", "/DIR=C:\OpenSSL", "/LOG=openssl.log" `
+            -Wait
+
+          Write-Host "Installation complete."
+          Write-Host "OpenSSL installation log:"
+          Get-Content -Path "openssl.log"
+          Write-Host "OpenSSL installation log end."
+
+          Write-Host "Cleaning up..."
+          Remove-Item -Path $output
+          Write-Host "Cleanup complete."
+
       - name: Prebuild
         if: matrix.prebuild_cmd
         run: |
-          eval "${{ matrix.prebuild_cmd }}"
+          ${{ matrix.prebuild_cmd }}
 
       - name: Build Debug
         run: |


### PR DESCRIPTION
This PR enables the Win32/x86 build on Windows. It required installing a Universal OpenSSL package which is done via PowerShell. I had attempted different approaches to installing this such as winget (interestingly, not actually installed on the runners by default) and choco (no arm package available, which was part of my original intent of this PR).

The `windows-11-arm` image is supposed to include OpenSSL, and actually after installing the universal package it produces the same exact errors during linking. So for this purpose I have disabled the arm build. Perhaps something else needs to be modified for arm support?

```
PlatformCrypto.obj : error LNK2019: unresolved external symbol EVP_EncryptInit_ex referenced in function PltEncryptMessage [D:\a\moonlight-common-c\moonlight-common-c\build_debug\moonlight-common-c.vcxproj]
PlatformCrypto.obj : error LNK2019: unresolved external symbol EVP_EncryptUpdate referenced in function PltEncryptMessage [D:\a\moonlight-common-c\moonlight-common-c\build_debug\moonlight-common-c.vcxproj]
PlatformCrypto.obj : error LNK2019: unresolved external symbol EVP_EncryptFinal_ex referenced in function PltEncryptMessage [D:\a\moonlight-common-c\moonlight-common-c\build_debug\moonlight-common-c.vcxproj]
PlatformCrypto.obj : error LNK2019: unresolved external symbol EVP_DecryptInit_ex referenced in function PltDecryptMessage [D:\a\moonlight-common-c\moonlight-common-c\build_debug\moonlight-common-c.vcxproj]
PlatformCrypto.obj : error LNK2019: unresolved external symbol EVP_DecryptUpdate referenced in function PltDecryptMessage [D:\a\moonlight-common-c\moonlight-common-c\build_debug\moonlight-common-c.vcxproj]
PlatformCrypto.obj : error LNK2019: unresolved external symbol EVP_DecryptFinal_ex referenced in function PltDecryptMessage [D:\a\moonlight-common-c\moonlight-common-c\build_debug\moonlight-common-c.vcxproj]
PlatformCrypto.obj : error LNK2019: unresolved external symbol EVP_CIPHER_CTX_new referenced in function PltCreateCryptoContext [D:\a\moonlight-common-c\moonlight-common-c\build_debug\moonlight-common-c.vcxproj]
PlatformCrypto.obj : error LNK2019: unresolved external symbol EVP_CIPHER_CTX_free referenced in function PltDestroyCryptoContext [D:\a\moonlight-common-c\moonlight-common-c\build_debug\moonlight-common-c.vcxproj]
PlatformCrypto.obj : error LNK2019: unresolved external symbol EVP_CIPHER_CTX_ctrl referenced in function PltEncryptMessage [D:\a\moonlight-common-c\moonlight-common-c\build_debug\moonlight-common-c.vcxproj]
PlatformCrypto.obj : error LNK2019: unresolved external symbol EVP_aes_128_cbc referenced in function PltEncryptMessage [D:\a\moonlight-common-c\moonlight-common-c\build_debug\moonlight-common-c.vcxproj]
PlatformCrypto.obj : error LNK2019: unresolved external symbol EVP_aes_128_gcm referenced in function PltEncryptMessage [D:\a\moonlight-common-c\moonlight-common-c\build_debug\moonlight-common-c.vcxproj]
PlatformCrypto.obj : error LNK2019: unresolved external symbol RAND_bytes referenced in function PltGenerateRandomData [D:\a\moonlight-common-c\moonlight-common-c\build_debug\moonlight-common-c.vcxproj]
C:\OpenSSL\lib\VC\x64\MDd\libcrypto.lib : warning LNK4272: library machine type 'x64' conflicts with target machine type 'ARM64' [D:\a\moonlight-common-c\moonlight-common-c\build_debug\moonlight-common-c.vcxproj]
D:\a\moonlight-common-c\moonlight-common-c\build_debug\Debug\moonlight-common-c.dll : fatal error LNK1120: 12 unresolved externals [D:\a\moonlight-common-c\moonlight-common-c\build_debug\moonlight-common-c.vcxproj]
```