### PR TITLE
Fix some edge case on small MTU devices using qsv codec 

### DIFF
--- a/src/VideoDepacketizer.c
+++ b/src/VideoDepacketizer.c
@@ -495,10 +495,14 @@ static void reassembleFrame(int frameNumber) {
             qdu->decodeUnit.colorspace = (uint8_t)(qdu->decodeUnit.hdrActive ? COLORSPACE_REC_2020 : StreamConfig.colorSpace);
 
             // Invoke the key frame callback if needed
-            if (qdu->decodeUnit.frameType == FRAME_TYPE_IDR) {
+            if (nalChainHead->bufferType != BUFFER_TYPE_PICDATA || qdu->decodeUnit.frameType == FRAME_TYPE_IDR) {
+                qdu->decodeUnit.frameType = FRAME_TYPE_IDR;
                 notifyKeyFrameReceived();
             }
-
+            else {
+                qdu->decodeUnit.frameType = FRAME_TYPE_PFRAME;
+            }
+            
             nalChainHead = nalChainTail = NULL;
             nalChainDataLength = 0;
 


### PR DESCRIPTION
Add fall back logic to prevent edge case where SPS SPP is not included in the same packet and key IDR frame is mislabeled as P frame causing assertion error at validation. The problem seem to only happen with the qsvcodec, when the problem disappear after I switch to Nvidia CPU (potentially due to the SPS SPP being consistently inserted on every packet, which I did not test further)

The pull request, however, fixed my iPad Air's crashing issue due to the above edge case. The logic existed in the early version of moonlight but was removed when implementing the AV1 codec at this commit: e36bde4.