### PR TITLE
Add native trackpad input support

### DIFF
--- a/src/Input.h
+++ b/src/Input.h
@@ -195,4 +195,19 @@ typedef struct _SS_CONTROLLER_BATTERY_PACKET {
     uint8_t zero[1]; // Alignment/reserved
 } SS_CONTROLLER_BATTERY_PACKET, *PSS_CONTROLLER_BATTERY_PACKET;
 
+#define SS_TRACKPAD_MAGIC 0x55000008
+typedef struct _SS_TRACKPAD_PACKET {
+    NV_INPUT_HEADER header;
+    uint8_t eventType;
+    uint8_t zero[1]; // Alignment/reserved
+    uint16_t rotation;
+    uint32_t pointerId;
+    netfloat x;
+    netfloat y;
+    netfloat pressureOrDistance;
+    netfloat contactAreaMajor;
+    netfloat contactAreaMinor;
+} SS_TRACKPAD_PACKET, *PSS_TRACKPAD_PACKET;
+
+
 #pragma pack(pop)

--- a/src/InputStream.c
+++ b/src/InputStream.c
@@ -61,6 +61,7 @@ static struct {
 
 // Don't batch up/down/cancel events
 #define TOUCH_EVENT_IS_BATCHABLE(x) ((x) == LI_TOUCH_EVENT_HOVER || (x) == LI_TOUCH_EVENT_MOVE)
+#define TRACKPAD_EVENT_IS_BATCHABLE(x) ((x) == LI_TRACKPAD_EVENT_FINGER_MOVE)
 
 // Contains input stream packets
 typedef struct _PACKET_HOLDER {
@@ -84,6 +85,7 @@ typedef struct _PACKET_HOLDER {
         NV_HAPTICS_PACKET haptics;
         SS_TOUCH_PACKET touch;
         SS_PEN_PACKET pen;
+        SS_TRACKPAD_PACKET trackpad;
         SS_CONTROLLER_ARRIVAL_PACKET controllerArrival;
         SS_CONTROLLER_TOUCH_PACKET controllerTouch;
         SS_CONTROLLER_MOTION_PACKET controllerMotion;
@@ -1299,6 +1301,53 @@ int LiSendHighResHScrollEvent(short scrollAmount) {
 
 int LiSendHScrollEvent(signed char scrollClicks) {
     return LiSendHighResHScrollEvent(scrollClicks * LI_WHEEL_DELTA);
+}
+
+int LiSendTrackpadEvent(uint8_t eventType, uint32_t pointerId, float x, float y, float pressureOrDistance,
+                        float contactAreaMajor, float contactAreaMinor, uint16_t rotation) {
+    PPACKET_HOLDER holder;
+    int err;
+
+    if (!initialized) {
+        return -2;
+    }
+
+    // This is a protocol extension only supported with Sunshine
+    if (!(SunshineFeatureFlags & LI_FF_TRACKPAD_EVENTS)) {
+        return LI_ERR_UNSUPPORTED;
+    }
+
+    holder = allocatePacketHolder(0);
+    if (holder == NULL) {
+        return -1;
+    }
+
+    holder->channelId = CTRL_CHANNEL_TRACKPAD;
+
+    // Allow move and hover events to be dropped if a newer one arrives, but don't allow
+    // state changing events like up/down/leave events to be dropped.
+    holder->enetPacketFlags = TRACKPAD_EVENT_IS_BATCHABLE(eventType) ? 0 : ENET_PACKET_FLAG_RELIABLE;
+
+    holder->packet.trackpad.header.size = BE32(sizeof(SS_TRACKPAD_PACKET) - sizeof(uint32_t));
+    holder->packet.trackpad.header.magic = LE32(SS_TRACKPAD_MAGIC);
+    holder->packet.trackpad.eventType = eventType;
+    holder->packet.trackpad.pointerId = LE32(pointerId);
+    holder->packet.trackpad.rotation = LE16(rotation);
+    memset(holder->packet.trackpad.zero, 0, sizeof(holder->packet.trackpad.zero));
+    floatToNetfloat(x, holder->packet.trackpad.x);
+    floatToNetfloat(y, holder->packet.trackpad.y);
+    floatToNetfloat(pressureOrDistance, holder->packet.trackpad.pressureOrDistance);
+    floatToNetfloat(contactAreaMajor, holder->packet.trackpad.contactAreaMajor);
+    floatToNetfloat(contactAreaMinor, holder->packet.trackpad.contactAreaMinor);
+
+    err = LbqOfferQueueItem(&packetQueue, holder, &holder->entry);
+    if (err != LBQ_SUCCESS) {
+        LC_ASSERT(err == LBQ_BOUND_EXCEEDED);
+        Limelog("Input queue reached maximum size limit\n");
+        freePacketHolder(holder);
+    }
+
+    return err;
 }
 
 int LiSendTouchEvent(uint8_t eventType, uint32_t pointerId, float x, float y, float pressureOrDistance,

--- a/src/Limelight-internal.h
+++ b/src/Limelight-internal.h
@@ -61,6 +61,7 @@ extern uint32_t EncryptionFeaturesEnabled;
 #define CTRL_CHANNEL_PEN          0x04
 #define CTRL_CHANNEL_TOUCH        0x05
 #define CTRL_CHANNEL_UTF8         0x06
+#define CTRL_CHANNEL_TRACKPAD     0x07
 #define CTRL_CHANNEL_GAMEPAD_BASE 0x10 // 0x10 to 0x1F by controller index
 #define CTRL_CHANNEL_SENSOR_BASE  0x20 // 0x20 to 0x2F by controller index
 #define CTRL_CHANNEL_COUNT        0x30

--- a/src/Limelight.h
+++ b/src/Limelight.h
@@ -677,6 +677,16 @@ int LiSendPenEvent(uint8_t eventType, uint8_t toolType, uint8_t penButtons,
                    float contactAreaMajor, float contactAreaMinor,
                    uint16_t rotation, uint8_t tilt);
 
+#define LI_TRACKPAD_EVENT_FINGER_DOWN   0x00
+#define LI_TRACKPAD_EVENT_FINGER_UP     0x01
+#define LI_TRACKPAD_EVENT_FINGER_MOVE   0x02
+#define LI_TRACKPAD_EVENT_BUTTON_DOWN   0x03
+#define LI_TRACKPAD_EVENT_BUTTON_UP     0x04
+#define LI_TRACKPAD_EVENT_CANCEL_ALL    0x05
+#define LI_ROT_UNKNOWN 0xFFFF
+int LiSendTrackpadEvent(uint8_t eventType, uint32_t pointerId, float x, float y, float pressureOrDistance,
+                        float contactAreaMajor, float contactAreaMinor, uint16_t rotation);
+
 // This function queues a mouse button event to be sent to the remote server.
 #define BUTTON_ACTION_PRESS 0x07
 #define BUTTON_ACTION_RELEASE 0x08
@@ -963,6 +973,7 @@ void LiRequestIdrFrame(void);
 // This function returns any extended feature flags supported by the host.
 #define LI_FF_PEN_TOUCH_EVENTS        0x01 // LiSendTouchEvent()/LiSendPenEvent() supported
 #define LI_FF_CONTROLLER_TOUCH_EVENTS 0x02 // LiSendControllerTouchEvent() supported
+#define LI_FF_TRACKPAD_EVENTS         0x04 // LiSendTrackpadEvent() supported for trackpads
 uint32_t LiGetHostFeatureFlags(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Current implementations (e.g. moonlight-android explicitly, and moonlight-qt implicitly) convert trackpad events into mouse actions, which inherently loses some information (e.g. gestures such as pinch-to-zoom and multi-finger swipes do not go through, scrolls are inprecise)

This PR adds a new channel for trackpad inputs. This is similar to a touch device (i.e. has positional "fingers"), with an additional button press for pressing the trackpad.

Similarly to touchscreen events, this is behind a feature-flag (which is currently implemented in my fork of sunshine, and my fork of moonlight-android, both of which I will be making a PR for).