### PR TITLE
Support cmake-4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1...4.0)
 project(moonlight-common-c LANGUAGES C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)


### PR DESCRIPTION
From https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-version:
- Changed in version 4.0: Compatibility with versions of CMake older than 3.5 is removed. Calls to [cmake_minimum_required(VERSION)](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required) or [cmake_policy(VERSION)](https://cmake.org/cmake/help/latest/command/cmake_policy.html#version) that do not specify at least 3.5 as their policy version (optionally via `...<max>`) will produce an error in CMake 4.0 and above.

Instead of bumping min version periodically it's easier to set up a range and forget about that for the time being. Now it won't break until cmake drops support for version 4.0, which won't happen in a long time.