### PR TITLE
Better support for fractional framerates

### DIFF
--- a/src/Limelight.h
+++ b/src/Limelight.h
@@ -100,10 +100,22 @@ typedef struct _STREAM_CONFIGURATION {
     // in /launch and /resume requests.
     char remoteInputAesKey[16];
     char remoteInputAesIv[16];
+
+    // Fractional frame rate of the video stream (in the form of numerator
+    // and denominator). Supported by recent versions of Sunshine.
+    // The non-fractional frame rate still needs to be specified for backward
+    // compatibility. LiConvertFloatingPointFrameRateToFraction() can be used for
+    // converting floating-point frame rates to this representation.
+    int fpsNum;
+    int fpsDen;
 } STREAM_CONFIGURATION, *PSTREAM_CONFIGURATION;
 
 // Use this function to zero the stream configuration when allocated on the stack or heap
 void LiInitializeStreamConfiguration(PSTREAM_CONFIGURATION streamConfig);
+
+// Use this function to convert floating-point frame rates to fractional frame
+// rates (in the form of numerator and denominator) while trying to maximize precision.
+void LiConvertFloatingPointFrameRateToFraction(double value, int* outNum, int* outDen);
 
 // These identify codec configuration data in the buffer lists
 // of frames identified as IDR frames for H.264 and HEVC formats.

--- a/src/SdpGenerator.c
+++ b/src/SdpGenerator.c
@@ -309,6 +309,15 @@ static PSDP_OPTION getAttributesList(char*urlSafeAddr) {
         else {
             err |= addAttributeString(&optionHead, "x-ss-video[0].chromaSamplingType", "0");
         }
+
+        // Specify fractional frame rate if requested
+        if (StreamConfig.fpsNum > 0 && StreamConfig.fpsDen > 0) {
+            snprintf(payloadStr, sizeof(payloadStr), "%d", StreamConfig.fpsNum);
+            err |= addAttributeString(&optionHead, "x-ml-video.targetFrameRateNum", payloadStr);
+
+            snprintf(payloadStr, sizeof(payloadStr), "%d", StreamConfig.fpsDen);
+            err |= addAttributeString(&optionHead, "x-ml-video.targetFrameRateDen", payloadStr);
+        }
     }
 
     snprintf(payloadStr, sizeof(payloadStr), "%d", StreamConfig.width);


### PR DESCRIPTION
Related to https://github.com/LizardByte/Sunshine/pull/4019

This introduces two new SDP media attributes `x-ml-video.targetFrameRateNum` and `x-ml-video.targetFrameRateDen`, and updates `Limelight.h` to make full use of them.