### PR TITLE
Add MAC address field to SERVER_INFORMATION structure

### DIFF
--- a/src/Limelight.h
+++ b/src/Limelight.h
@@ -532,6 +532,9 @@ typedef struct _SERVER_INFORMATION {
 
     // Specifies the 'ServerCodecModeSupport' from the /serverinfo response.
     int serverCodecModeSupport;
+
+    // MAC address string (XX:XX:XX:XX:XX:XX or similar)
+    char mac[18];
 } SERVER_INFORMATION, *PSERVER_INFORMATION;
 
 // Use this function to zero the server information when allocated on the stack or heap


### PR DESCRIPTION
This patch adds a char mac[18] field to the SERVER_INFORMATION struct to allow clients to store and access the MAC address reported by Sunshine's /serverinfo endpoint.

On some platforms, such as PlayStation Vita, it is not possible to obtain the MAC address using ARP or similar system calls, as those APIs are not available. By exposing the MAC address directly from Sunshine, clients can reliably retrieve and persist it after pairing.

This is especially useful for features like Wake-on-LAN, which require the host's MAC address to function. The field is optional and does not affect existing clients: if unused, it remains empty and does not impact API compatibility or behavior.

This change is safe and non-breaking for all consumers of the library.