### PR TITLE
feat(protocol): TLV metadata on controller arrival, player LED and mic LED extensions

### DIFF
--- a/src/ControlStream.c
+++ b/src/ControlStream.c
@@ -83,6 +83,14 @@ typedef struct _QUEUED_ASYNC_CALLBACK {
             uint8_t left[DS_EFFECT_PAYLOAD_SIZE];
             uint8_t right[DS_EFFECT_PAYLOAD_SIZE];
         } dsAdaptiveTrigger;
+        struct {
+            uint16_t controllerNumber;
+            uint8_t ledValue;
+        } setPlayerLed;
+        struct {
+            uint16_t controllerNumber;
+            uint8_t ledState;
+        } setMicLed;
     } data;
     LINKED_BLOCKING_QUEUE_ENTRY entry;
 } QUEUED_ASYNC_CALLBACK, *PQUEUED_ASYNC_CALLBACK;
@@ -140,6 +148,8 @@ static PPLT_CRYPTO_CONTEXT decryptionCtx;
 #define IDX_SET_MOTION_EVENT 10
 #define IDX_SET_RGB_LED 11
 #define IDX_DS_ADAPTIVE_TRIGGERS 12
+#define IDX_SET_PLAYER_LED 13
+#define IDX_SET_MIC_LED 14
 
 #define CONTROL_STREAM_TIMEOUT_SEC 10
 #define CONTROL_STREAM_LINGER_TIMEOUT_SEC 2
@@ -214,6 +224,8 @@ static const short packetTypesGen7Enc[] = {
     0x5501, // Set motion event (Sunshine protocol extension)
     0x5502, // Set RGB LED (Sunshine protocol extension)
     0x5503, // Set Adaptive Triggers (Sunshine protocol extension)
+    0x5504, // Set Player LED (Sunshine protocol extension)
+    0x5505, // Set Mic LED (Sunshine protocol extension)
 };
 
 static const char requestIdrFrameGen3[] = { 0, 0 };
@@ -1010,6 +1022,14 @@ static void asyncCallbackThreadFunc(void* context) {
                                                   queuedCb->data.dsAdaptiveTrigger.left,
                                                   queuedCb->data.dsAdaptiveTrigger.right);
             break;
+        case IDX_SET_PLAYER_LED:
+            ListenerCallbacks.setPlayerLed(queuedCb->data.setPlayerLed.controllerNumber,
+                                           queuedCb->data.setPlayerLed.ledValue);
+            break;
+        case IDX_SET_MIC_LED:
+            ListenerCallbacks.setMicLed(queuedCb->data.setMicLed.controllerNumber,
+                                        queuedCb->data.setMicLed.ledState);
+            break;
         default:
             // Unhandled packet type from queueAsyncCallback()
             LC_ASSERT(false);
@@ -1026,7 +1046,9 @@ static bool needsAsyncCallback(unsigned short packetType) {
            packetType == packetTypes[IDX_SET_MOTION_EVENT] ||
            packetType == packetTypes[IDX_SET_RGB_LED] ||
            packetType == packetTypes[IDX_HDR_INFO] ||
-           packetType == packetTypes[IDX_DS_ADAPTIVE_TRIGGERS];
+           packetType == packetTypes[IDX_DS_ADAPTIVE_TRIGGERS] ||
+           packetType == packetTypes[IDX_SET_PLAYER_LED] ||
+           packetType == packetTypes[IDX_SET_MIC_LED];
 }
 
 static void queueAsyncCallback(PNVCTL_ENET_PACKET_HEADER_V1 ctlHdr, int packetLength) {
@@ -1086,6 +1108,16 @@ static void queueAsyncCallback(PNVCTL_ENET_PACKET_HEADER_V1 ctlHdr, int packetLe
         BbGetBytes(&bb, queuedCb->data.dsAdaptiveTrigger.left, DS_EFFECT_PAYLOAD_SIZE);
         BbGetBytes(&bb, queuedCb->data.dsAdaptiveTrigger.right, DS_EFFECT_PAYLOAD_SIZE);
         queuedCb->typeIndex = IDX_DS_ADAPTIVE_TRIGGERS;
+    }
+    else if (ctlHdr->type == packetTypes[IDX_SET_PLAYER_LED]) {
+        BbGet16(&bb, &queuedCb->data.setPlayerLed.controllerNumber);
+        BbGet8(&bb, &queuedCb->data.setPlayerLed.ledValue);
+        queuedCb->typeIndex = IDX_SET_PLAYER_LED;
+    }
+    else if (ctlHdr->type == packetTypes[IDX_SET_MIC_LED]) {
+        BbGet16(&bb, &queuedCb->data.setMicLed.controllerNumber);
+        BbGet8(&bb, &queuedCb->data.setMicLed.ledState);
+        queuedCb->typeIndex = IDX_SET_MIC_LED;
     }
     else {
         // Unhandled packet type from needsAsyncCallback()

--- a/src/Input.h
+++ b/src/Input.h
@@ -163,6 +163,15 @@ typedef struct _SS_CONTROLLER_ARRIVAL_PACKET {
     uint32_t supportedButtonFlags;
 } SS_CONTROLLER_ARRIVAL_PACKET, *PSS_CONTROLLER_ARRIVAL_PACKET;
 
+// Controller metadata TLV entry, appended after the fixed arrival fields.
+// Multiple entries can be concatenated.
+typedef struct _SS_CONTROLLER_META_TLV {
+    uint8_t tag;       // LI_CTRL_META_TAG_*
+    uint8_t reserved;  // Must be 0
+    uint16_t length;   // Length of value data in bytes (little-endian)
+    // Followed by `length` bytes of value
+} SS_CONTROLLER_META_TLV, *PSS_CONTROLLER_META_TLV;
+
 #define SS_CONTROLLER_TOUCH_MAGIC 0x55000005
 typedef struct _SS_CONTROLLER_TOUCH_PACKET {
     NV_INPUT_HEADER header;

--- a/src/InputStream.c
+++ b/src/InputStream.c
@@ -1423,8 +1423,9 @@ int LiSendPenEvent(uint8_t eventType, uint8_t toolType, uint8_t penButtons,
     return err;
 }
 
-int LiSendControllerArrivalEvent(uint8_t controllerNumber, uint16_t activeGamepadMask, uint8_t type,
-                                 uint32_t supportedButtonFlags, uint16_t capabilities) {
+int LiSendControllerArrivalEventWithMetadata(uint8_t controllerNumber, uint16_t activeGamepadMask,
+                                             uint8_t type, uint32_t supportedButtonFlags, uint16_t capabilities,
+                                             const uint8_t *metadataBlob, uint16_t metadataBlobLen) {
     PPACKET_HOLDER holder;
     int err;
 
@@ -1437,7 +1438,7 @@ int LiSendControllerArrivalEvent(uint8_t controllerNumber, uint16_t activeGamepa
 
     // The arrival event is only supported by Sunshine
     if (IS_SUNSHINE()) {
-        holder = allocatePacketHolder(0);
+        holder = allocatePacketHolder(metadataBlobLen);
         if (holder == NULL) {
             return -1;
         }
@@ -1446,12 +1447,19 @@ int LiSendControllerArrivalEvent(uint8_t controllerNumber, uint16_t activeGamepa
         holder->channelId = CTRL_CHANNEL_GAMEPAD_BASE + controllerNumber;
         holder->enetPacketFlags = ENET_PACKET_FLAG_RELIABLE;
 
-        holder->packet.controllerArrival.header.size = BE32(sizeof(SS_CONTROLLER_ARRIVAL_PACKET) - sizeof(uint32_t));
+        uint32_t totalSize = sizeof(SS_CONTROLLER_ARRIVAL_PACKET) + metadataBlobLen;
+        holder->packet.controllerArrival.header.size = BE32(totalSize - sizeof(uint32_t));
         holder->packet.controllerArrival.header.magic = LE32(SS_CONTROLLER_ARRIVAL_MAGIC);
         holder->packet.controllerArrival.controllerNumber = controllerNumber;
         holder->packet.controllerArrival.type = type;
         holder->packet.controllerArrival.capabilities = LE16(capabilities);
         holder->packet.controllerArrival.supportedButtonFlags = LE32(supportedButtonFlags);
+
+        // Append metadata TLV entries after the fixed arrival fields
+        if (metadataBlob && metadataBlobLen > 0) {
+            memcpy((uint8_t *)&holder->packet.controllerArrival + sizeof(SS_CONTROLLER_ARRIVAL_PACKET),
+                   metadataBlob, metadataBlobLen);
+        }
 
         err = LbqOfferQueueItem(&packetQueue, holder, &holder->entry);
         if (err != LBQ_SUCCESS) {
@@ -1464,6 +1472,13 @@ int LiSendControllerArrivalEvent(uint8_t controllerNumber, uint16_t activeGamepa
 
     // Send a MC event just in case the host software doesn't support arrival events.
     return LiSendMultiControllerEvent(controllerNumber, activeGamepadMask, 0, 0, 0, 0, 0, 0, 0);
+}
+
+int LiSendControllerArrivalEvent(uint8_t controllerNumber, uint16_t activeGamepadMask, uint8_t type,
+                                 uint32_t supportedButtonFlags, uint16_t capabilities) {
+    return LiSendControllerArrivalEventWithMetadata(controllerNumber, activeGamepadMask,
+                                                    type, supportedButtonFlags, capabilities,
+                                                    NULL, 0);
 }
 
 int LiSendControllerTouchEvent(uint8_t controllerNumber, uint8_t eventType, uint32_t pointerId, float x, float y, float pressure) {

--- a/src/Limelight.h
+++ b/src/Limelight.h
@@ -483,6 +483,14 @@ typedef void(*ConnListenerSetAdaptiveTriggers)(uint16_t controllerNumber, uint8_
 // This callback is invoked to set a controller's RGB LED (if present).
 typedef void(*ConnListenerSetControllerLED)(uint16_t controllerNumber, uint8_t r, uint8_t g, uint8_t b);
 
+// This callback is invoked to set a controller's player indicator LEDs.
+// The ledValue is a bitmask of 5 LEDs (bits 0-4).
+typedef void(*ConnListenerSetPlayerLed)(uint16_t controllerNumber, uint8_t ledValue);
+
+// This callback is invoked to set a controller's mic mute LED state.
+// Values: 0 = off, 1 = on (solid), 2 = pulse (blink)
+typedef void(*ConnListenerSetMicLed)(uint16_t controllerNumber, uint8_t ledState);
+
 typedef struct _CONNECTION_LISTENER_CALLBACKS {
     ConnListenerStageStarting stageStarting;
     ConnListenerStageComplete stageComplete;
@@ -497,6 +505,8 @@ typedef struct _CONNECTION_LISTENER_CALLBACKS {
     ConnListenerSetMotionEventState setMotionEventState;
     ConnListenerSetControllerLED setControllerLED;
     ConnListenerSetAdaptiveTriggers setAdaptiveTriggers;
+    ConnListenerSetPlayerLed setPlayerLed;
+    ConnListenerSetMicLed setMicLed;
 } CONNECTION_LISTENER_CALLBACKS, *PCONNECTION_LISTENER_CALLBACKS;
 
 // Use this function to zero the connection callbacks when allocated on the stack or heap

--- a/src/Limelight.h
+++ b/src/Limelight.h
@@ -781,8 +781,22 @@ int LiSendMultiControllerEvent(short controllerNumber, short activeGamepadMask,
 #define LI_CCAP_GYRO            0x20 // Can report gyroscope events via LiSendControllerMotionEvent()
 #define LI_CCAP_BATTERY_STATE   0x40 // Reports battery state via LiSendControllerBatteryEvent()
 #define LI_CCAP_RGB_LED         0x80 // Can set RGB LED state via ConnListenerSetControllerLED()
+#define LI_CCAP_FIRMWARE_INFO   0x100 // Has firmware info available for passthrough
 int LiSendControllerArrivalEvent(uint8_t controllerNumber, uint16_t activeGamepadMask, uint8_t type,
                                  uint32_t supportedButtonFlags, uint16_t capabilities);
+
+// Controller metadata TLV tags for extended arrival events.
+// TLV entries are appended after the fixed SS_CONTROLLER_ARRIVAL_PACKET fields.
+// Each entry is: tag (1 byte) + reserved (1 byte) + length (2 bytes LE) + value (length bytes).
+#define LI_CTRL_META_TAG_FIRMWARE_INFO  0x01 // Value: 64 bytes of raw HID feature report 0x20
+
+// Extended version of LiSendControllerArrivalEvent that includes optional
+// controller metadata as a buffer of concatenated TLV entries.
+// If metadataBlob is NULL or metadataBlobLen is 0, this behaves identically
+// to LiSendControllerArrivalEvent().
+int LiSendControllerArrivalEventWithMetadata(uint8_t controllerNumber, uint16_t activeGamepadMask,
+                                             uint8_t type, uint32_t supportedButtonFlags, uint16_t capabilities,
+                                             const uint8_t *metadataBlob, uint16_t metadataBlobLen);
 
 // This function is similar to LiSendTouchEvent(), but the touch events are associated with a
 // touchpad device present on a game controller instead of a touchscreen.


### PR DESCRIPTION
## Summary
Adds three Sunshine protocol extensions for DualSense controller support:

**TLV metadata on controller arrival:**
- `LiSendControllerArrivalEventWithMetadata()` appends optional TLV (Type-Length-Value) entries after the fixed arrival packet fields
- Defined tag `LI_CTRL_META_TAG_FIRMWARE_INFO` (0x01): carries the raw 64-byte HID feature report 0x20 from the client's physical controller
- Existing `LiSendControllerArrivalEvent()` preserved as a thin wrapper (backwards compatible)
- Old hosts ignore trailing bytes; old clients don't send them

**Player LED (0x5504):**
- Forwards the 5-bit player indicator LED bitmask from host to client
- Standard values: P1=0x04, P2=0x0A, P3=0x15, P4=0x1B, all=0x1F

**Mic LED (0x5505):**
- Forwards the mic mute LED state from host to client
- Values: 0=off, 1=on (solid), 2=pulse (blink)

Adds `ConnListenerSetPlayerLed` and `ConnListenerSetMicLed` to `CONNECTION_LISTENER_CALLBACKS`.

## Context
These extensions support Sunshine's WinUHid-based virtual DualSense emulation on Windows (LizardByte/Sunshine#4948). The firmware passthrough prevents spurious "firmware update required" prompts, and the LED extensions enable full DualSense indicator fidelity during streaming.

## Test plan
- [x] Firmware TLV parsed correctly by Sunshine, real firmware version appears on virtual DualSense
- [x] Player LED and mic LED states forwarded end-to-end from host game to physical controller on client
- [x] Backwards compatible: old clients without metadata work unchanged, old hosts ignore trailing bytes