### PR TITLE
Fix intermittent video freezes caused by packet reordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,13 @@ jobs:
           mkdir build_release
           cmake ${{ matrix.cmake_args }} -DCMAKE_BUILD_TYPE=Release -B build_release -S .
           cmake --build build_release --config Release
+
+      - name: Test RTP video queue
+        if: runner.os == 'Linux'
+        run: |
+          for mode in Debug Release; do
+            cmake -S tests -B "build_tests_$mode" \
+              -DCMAKE_BUILD_TYPE="$mode" -DCMAKE_C_COMPILER=${{ matrix.cc }}
+            cmake --build "build_tests_$mode"
+            ctest --test-dir "build_tests_$mode" --output-on-failure
+          done

--- a/src/RtpVideoQueue.c
+++ b/src/RtpVideoQueue.c
@@ -14,6 +14,9 @@
 // an out of order packet or incorrect prediction
 #define SPECULATIVE_RFI_COOLDOWN_PERIOD_US 300000000
 
+// Allow brief packet reordering to resolve before predicting unrecoverable loss.
+#define SPECULATIVE_RFI_GRACE_PERIOD_US 2000
+
 // RTP packets use a 90 KHz presentation timestamp clock
 #define PTS_DIVISOR 90
 
@@ -216,10 +219,24 @@ static int reconstructFrame(PRTP_VIDEO_QUEUE queue) {
             // NB: We use totalPackets - neededPackets instead of just bufferParityPackets here because we require
             // one extra parity shard for recovery if we're in FEC validation mode.
             if (queue->missingPackets > totalPackets - neededPackets) {
-                notifyFrameLost(queue->currentFrameNumber, true);
-                queue->reportedLostFrame = true;
+                uint64_t now = PltGetMicroseconds();
+
+                // A reordered batch can temporarily leave more holes than FEC can repair.
+                // notifyFrameLost() drops depacketizer state, so a prediction cannot be
+                // undone when those packets arrive. Allow a short grace period first.
+                // If no more packets arrive, the next frame still triggers the normal
+                // non-speculative loss notification.
+                if (queue->speculativeLossDetectedTimeUs == 0) {
+                    queue->speculativeLossDetectedTimeUs = now;
+                }
+                else if (now - queue->speculativeLossDetectedTimeUs >= SPECULATIVE_RFI_GRACE_PERIOD_US) {
+                    notifyFrameLost(queue->currentFrameNumber, true);
+                    queue->reportedLostFrame = true;
+                }
             }
             else {
+                queue->speculativeLossDetectedTimeUs = 0;
+
                 // Assert that there are enough remaining packets to possibly recover this frame.
                 LC_ASSERT(neededPackets - queue->pendingFecBlockList.count <= U16(queue->bufferHighestSequenceNumber - queue->receivedHighestSequenceNumber));
             }
@@ -701,6 +718,7 @@ int RtpvAddPacket(PRTP_VIDEO_QUEUE queue, PRTP_PACKET packet, int length, PRTPV_
         queue->missingPackets = 0;
         queue->useFastQueuePath = true;
         queue->reportedLostFrame = false;
+        queue->speculativeLossDetectedTimeUs = 0;
         queue->bufferDataPackets = (nvPacket->fecInfo & 0xFFC00000) >> 22;
         queue->fecPercentage = (nvPacket->fecInfo & 0xFF0) >> 4;
         queue->bufferParityPackets = (queue->bufferDataPackets * queue->fecPercentage + 99) / 100;

--- a/src/RtpVideoQueue.h
+++ b/src/RtpVideoQueue.h
@@ -37,6 +37,7 @@ typedef struct _RTP_VIDEO_QUEUE {
     uint32_t missingPackets; // # of holes behind receivedHighestSequenceNumber
     bool useFastQueuePath;
     bool reportedLostFrame;
+    uint64_t speculativeLossDetectedTimeUs;
 
     uint32_t currentFrameNumber;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
+project(rtp_video_queue_tests C)
+
+enable_testing()
+find_package(OpenSSL REQUIRED)
+add_executable(rtp_video_queue_tests
+    test_rtp_video_queue.c
+    ../src/RtpVideoQueue.c
+    ../nanors/rs.c
+    ../nanors/deps/obl/oblas_common.c
+    ../nanors/deps/obl/oblas_lite.c)
+target_compile_features(rtp_video_queue_tests PRIVATE c_std_11)
+target_compile_definitions(rtp_video_queue_tests PRIVATE HAS_SOCKLEN_T)
+target_compile_definitions(rtp_video_queue_tests PRIVATE $<$<CONFIG:Debug>:LC_DEBUG>)
+target_include_directories(rtp_video_queue_tests PRIVATE
+    ../src ../enet/include ../nanors ../nanors/deps ../nanors/deps/obl)
+target_link_libraries(rtp_video_queue_tests PRIVATE OpenSSL::Crypto)
+if(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(rtp_video_queue_tests PRIVATE -Wall -Wextra -Werror -Wno-unused-parameter)
+endif()
+add_test(NAME rtp_video_queue COMMAND rtp_video_queue_tests)

--- a/tests/test_rtp_video_queue.c
+++ b/tests/test_rtp_video_queue.c
@@ -1,0 +1,210 @@
+#include "Limelight-internal.h"
+
+// Exercise the real RTP queue with a deterministic clock and synthetic packets.
+// The control stream and depacketizer endpoints only record queue outputs.
+int AppVersionQuad[4] = {7, 1, 431, -1};
+STREAM_CONFIGURATION StreamConfig;
+CONNECTION_LISTENER_CALLBACKS ListenerCallbacks;
+
+static uint64_t nowUs;
+static unsigned int speculativeReports;
+static unsigned int finalReports;
+static unsigned int lastLostFrame;
+static unsigned int submittedPackets;
+static uint16_t expectedSequence;
+static bool checkSequence;
+
+#define CHECK(condition) do { \
+    if (!(condition)) { \
+        fprintf(stderr, "%s:%d: %s\n", __FILE__, __LINE__, #condition); \
+        exit(1); \
+    } \
+} while (0)
+
+uint64_t PltGetMicroseconds(void) { return nowUs; }
+void connectionSawFrame(uint32_t frameIndex) { }
+void connectionSendFrameFecStatus(PSS_FRAME_FEC_STATUS fecStatus) { }
+void notifyFrameLost(unsigned int frameNumber, bool speculative) {
+    lastLostFrame = frameNumber;
+    if (speculative) speculativeReports++;
+    else finalReports++;
+}
+void queueRtpPacket(PRTPV_QUEUE_ENTRY entry) {
+    if (checkSequence) {
+        CHECK(entry->packet->sequenceNumber == expectedSequence);
+        expectedSequence++;
+    }
+    submittedPackets++;
+    free(entry->packet);
+}
+
+static void initialize(PRTP_VIDEO_QUEUE queue) {
+    nowUs = 1000000;
+    speculativeReports = finalReports = lastLostFrame = submittedPackets = 0;
+    expectedSequence = 0;
+    checkSequence = false;
+    StreamConfig.packetSize = 64;
+    RtpvInitializeQueue(queue);
+}
+
+static int sendPacket(PRTP_VIDEO_QUEUE queue, unsigned int frame, uint16_t base,
+                      unsigned int index, unsigned int dataPackets,
+                      unsigned int fecPercentage, unsigned int block,
+                      unsigned int lastBlock) {
+    int length = MAX_RTP_HEADER_SIZE + StreamConfig.packetSize;
+    PRTP_PACKET packet = calloc(1, length + sizeof(RTPV_QUEUE_ENTRY));
+    CHECK(packet != NULL);
+    PRTPV_QUEUE_ENTRY entry = (PRTPV_QUEUE_ENTRY)((char*)packet + length);
+    packet->header = FLAG_EXTENSION;
+    packet->sequenceNumber = (uint16_t)(base + index);
+    packet->timestamp = frame * 1500;
+    PNV_VIDEO_PACKET video = (PNV_VIDEO_PACKET)((char*)packet + sizeof(*packet) + 4);
+    video->frameIndex = LE32(frame);
+    video->streamPacketIndex = LE32(index << 8);
+    video->fecInfo = LE32((dataPackets << 22) | (index << 12) | (fecPercentage << 4));
+    video->multiFecFlags = 0x10;
+    video->multiFecBlocks = (uint8_t)((lastBlock << 6) | (block << 4));
+    video->flags = FLAG_CONTAINS_PIC_DATA;
+    if (index == 0) video->flags |= FLAG_SOF;
+    if (index == dataPackets - 1) video->flags |= FLAG_EOF;
+    int result = RtpvAddPacket(queue, packet, length, entry);
+    if (result == RTPF_RET_REJECTED) free(packet);
+    return result;
+}
+
+#define SEND(q, frame, base, index) sendPacket(q, frame, base, index, 48, 0, 0, 0)
+
+static void testOrdered(void) {
+    RTP_VIDEO_QUEUE q;
+    initialize(&q);
+    checkSequence = true;
+    for (unsigned int i = 0; i < 48; i++) CHECK(SEND(&q, 1, 0, i) == RTPF_RET_QUEUED);
+    CHECK(submittedPackets == 48);
+    CHECK(speculativeReports == 0 && finalReports == 0);
+    CHECK(nowUs == 1000000); // A complete frame never waits for the grace period.
+    RtpvCleanupQueue(&q);
+}
+
+static void testReordered(unsigned int delay, uint16_t base) {
+    RTP_VIDEO_QUEUE q;
+    initialize(&q);
+    checkSequence = true;
+    expectedSequence = base;
+    CHECK(SEND(&q, 1, base, 46) == RTPF_RET_QUEUED);
+    CHECK(SEND(&q, 1, base, 47) == RTPF_RET_QUEUED);
+    CHECK(speculativeReports == 0);
+    nowUs += delay;
+    for (unsigned int i = 0; i < 46; i++) CHECK(SEND(&q, 1, base, i) == RTPF_RET_QUEUED);
+    CHECK(submittedPackets == 48);
+    CHECK(speculativeReports == 0 && finalReports == 0);
+    CHECK(q.receivedOosData);
+    RtpvCleanupQueue(&q);
+}
+
+static void testPersistentLoss(void) {
+    RTP_VIDEO_QUEUE q;
+    initialize(&q);
+    SEND(&q, 1, 0, 10);
+    CHECK(speculativeReports == 0);
+    nowUs += 1999;
+    SEND(&q, 1, 0, 11);
+    CHECK(speculativeReports == 0);
+    nowUs++;
+    SEND(&q, 1, 0, 12);
+    CHECK(speculativeReports == 1 && lastLostFrame == 1);
+    nowUs += 5000;
+    SEND(&q, 1, 0, 13);
+    SEND(&q, 2, 48, 0);
+    CHECK(speculativeReports == 1 && finalReports == 0);
+    RtpvCleanupQueue(&q);
+}
+
+static void testBoundaryFallback(void) {
+    RTP_VIDEO_QUEUE q;
+    initialize(&q);
+    SEND(&q, 1, 0, 46);
+    nowUs += 16000; // No more packets from the lost frame.
+    SEND(&q, 2, 48, 0);
+    CHECK(speculativeReports == 0 && finalReports == 1 && lastLostFrame == 1);
+    RtpvCleanupQueue(&q);
+}
+
+static void testDuplicate(void) {
+    RTP_VIDEO_QUEUE q;
+    initialize(&q);
+    SEND(&q, 1, 0, 46);
+    nowUs += 3000;
+    CHECK(SEND(&q, 1, 0, 46) == RTPF_RET_REJECTED);
+    CHECK(speculativeReports == 0);
+    SEND(&q, 1, 0, 47);
+    CHECK(speculativeReports == 1);
+    RtpvCleanupQueue(&q);
+}
+
+static void testFrameReset(void) {
+    RTP_VIDEO_QUEUE q;
+    initialize(&q);
+    SEND(&q, 1, 0, 46);
+    nowUs += 10000;
+    SEND(&q, 2, 48, 46);
+    CHECK(finalReports == 1 && speculativeReports == 0);
+    nowUs += 1999;
+    SEND(&q, 2, 48, 47);
+    CHECK(speculativeReports == 0);
+    RtpvCleanupQueue(&q);
+}
+
+static void testCooldown(void) {
+    RTP_VIDEO_QUEUE q;
+    initialize(&q);
+    SEND(&q, 1, 0, 46);
+    SEND(&q, 1, 0, 0); // Observed reordering disables speculation.
+    nowUs += 10000;
+    SEND(&q, 1, 0, 47);
+    CHECK(q.receivedOosData && speculativeReports == 0);
+    RtpvCleanupQueue(&q);
+}
+
+static void testFecBudget(void) {
+    RTP_VIDEO_QUEUE q;
+    initialize(&q);
+    // 48 data + 24 parity. A 10-packet hole is recoverable in both normal
+    // and debug FEC-validation modes; a 45-packet hole exceeds either budget.
+    sendPacket(&q, 1, 0, 10, 48, 50, 0, 0);
+    nowUs += 10000;
+    sendPacket(&q, 1, 0, 11, 48, 50, 0, 0);
+    CHECK(speculativeReports == 0);
+    sendPacket(&q, 1, 0, 47, 48, 50, 0, 0);
+    CHECK(speculativeReports == 0);
+    nowUs += 2000;
+    sendPacket(&q, 1, 0, 48, 48, 50, 0, 0);
+    CHECK(speculativeReports == 1);
+    RtpvCleanupQueue(&q);
+}
+
+static void testMissingFecBlock(void) {
+    RTP_VIDEO_QUEUE q;
+    initialize(&q);
+    sendPacket(&q, 1, 0, 46, 48, 0, 0, 1);
+    nowUs += 500;
+    CHECK(sendPacket(&q, 1, 48, 0, 48, 0, 1, 1) == RTPF_RET_REJECTED);
+    CHECK(finalReports == 1 && speculativeReports == 0 && lastLostFrame == 1);
+    RtpvCleanupQueue(&q);
+}
+
+int main(void) {
+    testOrdered();
+    // All seven reported capture delays, plus the edge of the grace window.
+    const unsigned int delays[] = {68, 1, 3, 2, 3, 2, 3, 1999};
+    for (unsigned int i = 0; i < sizeof(delays) / sizeof(delays[0]); i++) testReordered(delays[i], 0);
+    testReordered(68, 65520); // RTP sequence wraparound.
+    testPersistentLoss();
+    testBoundaryFallback();
+    testDuplicate();
+    testFrameReset();
+    testCooldown();
+    testFecBudget();
+    testMissingFecBlock();
+    puts("PASS: 17 RTP queue cases (ordering, reordering, loss, boundaries, duplicates, cooldown, FEC budget, wraparound)");
+    return 0;
+}


### PR DESCRIPTION
Hello! I've been using Moonlight and Apollo for gaming on my local network. Things have generally run smoothly, but every 30 minutes to an hour I’ve been experiencing 1–2 second freezes with the client displaying `Slow connection to PC Reduce your bitrate`. Network tuning and configuration changes hadn’t resolved it.

To investigate further, I started multiple Claude Code instances (one on my Steam Deck and another on the server) in order to pin down the source of the issue. [Full investigation report](https://docs.google.com/document/d/195pZdIIA51q-fqF-ieF0lmcK05aDZOkQyJQWUoMIEk0/edit?tab=t.0#heading=h.d9vvhi6ve9il)
 
 The captures showed brief packet reordering, with a batch of 46 packets arriving 1–68 microseconds late and no packets actually lost. UDP doesn’t guarantee packet arrival order, so this wasn’t a protocol violation. However, Moonlight’s speculative loss detection treated the temporary gap as an unrecoverable frame loss and discarded frame state before the delayed packets arrived, triggering the freeze.

Interestingly the code already [has a comment](https://github.com/alexmckenley/moonlight-common-c/blob/12ad85f3fd61af9ad3b41410cf15c825cb5c5e63/src/RtpVideoQueue.c#L249-L250) describing this false-prediction case:

> If we make it here and reported a lost frame, we lied to the host. This can happen if we happen to get
unlucky and this particular frame happens to be the one with OOS data, but it should almost never happen.

With my setup, streaming at 1440p at 120hz via gigabit ethernet, I seem to run into this once every 30 mins or so. 

This fix adds a 2 ms grace period before reporting speculative frame loss, giving reordered packets time to arrive. Complete frames are still delivered immediately; the grace period only delays speculative loss reports.

I've been testing this fix for several weeks through a locally built Moonlight 6.1.0 Flatpak on my Steam Deck, and I haven't hit any freezes since then. Please let me know if there's any other testing or due diligence you would like here!

---
Environment:

[Full technical details](https://docs.google.com/document/d/195pZdIIA51q-fqF-ieF0lmcK05aDZOkQyJQWUoMIEk0/edit?tab=t.0#heading=h.d9vvhi6ve9il)

- **Host:** Windows 11 Pro, Apollo 0.4.6, Radeon RX 9070 using AMF.
- **Ethernet:** RTL8125B(G) 2.5GbE host NIC → gigabit switch → RTL8153 USB Ethernet dock on the Steam Deck.
- **Client:** SteamOS 3.8.16, Moonlight 6.1.0, HEVC Main10 through VAAPI.